### PR TITLE
fix: Detect top-level project directory name

### DIFF
--- a/scripts/python/lib/genesis.py
+++ b/scripts/python/lib/genesis.py
@@ -25,18 +25,17 @@ import re
 import yaml
 
 
-GENESIS_DIR = 'cluster-genesis'
-FILE_PATH = os.path.dirname(os.path.abspath(__file__))
+PROJECT_NAME = "power-up"
 HOME = os.path.expanduser('~')
-GEN_PATH = FILE_PATH[:1 + len(GENESIS_DIR) + FILE_PATH.find(GENESIS_DIR)]
+GEN_PATH = os.path.abspath(os.path.join(__file__, "../../../../")) + "/"
 GEN_SCRIPTS_PATH = os.path.join(GEN_PATH, 'scripts', '')
 GEN_SCRIPTS_PYTHON_PATH = os.path.join(GEN_SCRIPTS_PATH, 'python', '')
 GEN_PLAY_PATH = os.path.join(GEN_PATH, 'playbooks', '')
 GEN_PASSIVE_PATH = os.path.join(GEN_PATH, 'passive', '')
 GEN_LOGS_PATH = os.path.join(GEN_PATH, 'logs', '')
 OPSYS = platform.dist()[0]
-DEFAULT_CONTAINER_NAME = 'cluster-genesis'
-CONTAINER_PACKAGE_PATH = '/opt/' + GENESIS_DIR
+DEFAULT_CONTAINER_NAME = PROJECT_NAME
+CONTAINER_PACKAGE_PATH = '/opt/' + PROJECT_NAME
 CONTAINER_ID_FILE = 'container'
 VENV_DIR = 'gen-venv'
 DEPLOYER_VENV_DIR = 'deployenv'

--- a/scripts/python/lib/genesis.py
+++ b/scripts/python/lib/genesis.py
@@ -27,7 +27,8 @@ import yaml
 
 PROJECT_NAME = "power-up"
 HOME = os.path.expanduser('~')
-GEN_PATH = os.path.abspath(os.path.join(__file__, "../../../../")) + "/"
+GEN_PATH = (os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../../")) + "/")
 GEN_SCRIPTS_PATH = os.path.join(GEN_PATH, 'scripts', '')
 GEN_SCRIPTS_PYTHON_PATH = os.path.join(GEN_SCRIPTS_PATH, 'python', '')
 GEN_PLAY_PATH = os.path.join(GEN_PATH, 'playbooks', '')


### PR DESCRIPTION
The module 'genesis.py' assumed the top-level project directory would be
named 'cluster-genesis'. Git allows a project to use any name for the
top-level directory and so should we. After renaming the project GitHub
repository this is especially problematic since the default directory
name is now 'power-up'. This commit changes the 'GEN_PATH' algorithm to
rely on the relative location of the 'genesis.py' module. If
'genesis.py' were to be moved this code would also need to be updated.