### PR TITLE
 fix: Auto set project root in 'cleanpath'

### DIFF
--- a/scripts/cleanpath
+++ b/scripts/cleanpath
@@ -1,4 +1,6 @@
-#Copyright 2017 IBM Corp.
+#!/bin/bash
+
+#Copyright 2018 IBM Corp.
 #
 # All Rights Reserved.
 #
@@ -14,9 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# First handle embedded case, then the case where it leads
-PATH=${PATH/":"*"cluster-genesis/scripts"/}
-PATH=${PATH/*"cluster-genesis/scripts:"/}
-PATH=${PATH/":"*"cluster-genesis/deployenv/bin"/}
-PATH=${PATH/*"cluster-genesis/deployenv/bin:"/}
+# PROJECT_ROOT value modified by scripts/setup-env
+PROJECT_ROOT=$HOME/power-up
+
+for dir in scripts deployenv/bin; do
+    dir_path="$PROJECT_ROOT/$dir"
+    PATH=${PATH/"$dir_path:"}
+    PATH=${PATH/":$dir_path"}
+done
+
 export PATH

--- a/scripts/setup-env
+++ b/scripts/setup-env
@@ -60,3 +60,4 @@ if [ ! -d ~/bin ]; then
 fi
 
 cp $PROJECT_ROOT/scripts/cleanpath ~/bin
+sed -i 's,PROJECT_ROOT=.*,PROJECT_ROOT='"$PROJECT_ROOT"',' ~/bin/cleanpath


### PR DESCRIPTION
When 'setup-env' copies the 'cleanpath' script to '~/bin/cleanpath' sed
is used to set the 'PROJECT_ROOT' variable. This allows 'cleanpath' to
clean the shell's PATH regardless of the top level project directory
name, even after the project directory has been removed.