### PR TITLE
fix: Update project name in Ansible 'host_vars'

### DIFF
--- a/playbooks/host_vars/deployer
+++ b/playbooks/host_vars/deployer
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_path: /opt/cluster-genesis
+project_path: /opt/power-up
 scripts_path: "{{ project_path }}/scripts"
 venv_path: "{{ project_path }}/gen-venv"
 python_executable: "{{ venv_path }}/bin/python"

--- a/playbooks/host_vars/localhost
+++ b/playbooks/host_vars/localhost
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-container_name: cluster-genesis
-project_path_local: "{{ ansible_env['PWD'] | regex_replace('^(.+/cluster-genesis).+?$', '\\1')}}"
+container_name: power-up
+project_path_local: "{{ ansible_env['PWD'] | regex_replace('^(.+/power-up).+?$', '\\1')}}"
 scripts_path_local: "{{ project_path_local }}/scripts"
 venv_path_local: "{{ project_path_local }}/deployenv"
 python_executable_local: "{{ venv_path_local }}/bin/python"


### PR DESCRIPTION
Change project name references in Ansible 'host_vars' files from
'cluster-genesis' to 'power-up'. TODO: Add logic to allow any top level
directory name.