### PR TITLE
fix: Create empty log file to ensure user is owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ playbooks/known_hosts
 debug_data/
 playbooks/lxc.conf
 scripts/python/switch-test-cfg-*.yml
+logs/gen

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,3 +57,11 @@ source deployenv/bin/activate
 pip install 'ansible~=2.3.0.0' orderedattrdict pyroute2 jsonschema jsl \
     'pyghmi==1.0.28' 'wget==3.2'
 deactivate
+
+# Create empty log file to ensure user is owner
+if [ ! -d "logs" ]; then
+    mkdir logs
+    if [ ! -f logs/gen ]; then
+        touch logs/gen
+    fi
+fi


### PR DESCRIPTION
If 'teardown' is run before a log file ('logs/gen') is created then the
log file will be created with 'root' user as the owner and without write
privileges for other users. Subsequent attempts to write to the log file
as a non-root user will fail. Tracking a blank log file in the project
repository will ensure it will be created with the cloning user as
owner.