### PR TITLE
fix: Do not require top-level 'networks' in config

### DIFF
--- a/scripts/python/lib/validate_config_schema.py
+++ b/scripts/python/lib/validate_config_schema.py
@@ -218,9 +218,7 @@ class SchemaDefinition(jsl.Document):
         jsl.fields.DocumentField(Interfaces),
         required=True)
 
-    networks = jsl.fields.ArrayField(
-        jsl.fields.DocumentField(Networks),
-        required=True)
+    networks = jsl.fields.ArrayField(jsl.fields.DocumentField(Networks))
 
     node_templates = jsl.fields.ArrayField(required=True)
 


### PR DESCRIPTION
The configuration file top-level key 'networks' is not required.