### PR TITLE
docs: Document user password requirements

### DIFF
--- a/docs/Config-Specification.rst
+++ b/docs/Config-Specification.rst
@@ -866,7 +866,9 @@ node_templates:
 |                                    |                                               |                         (e.g. "controller-1" and "controoler-2").                |          |
 |                                    |                                               | |   *users*           - OS user accounts to create. All parameters in the        |          |
 |                                    |                                               |                         `Ansible user module <ansible_user_module_>`_ are        |          |
-|                                    |                                               |                         supported.                                               |          |
+|                                    |                                               |                         supported. **note:** Plaintext user passwords are not    |          |
+|                                    |                                               |                         supported. For help see                                  |          |
+|                                    |                                               |                         `Ansible's guide for generating passwords <gen_pass_>`_. |          |
 |                                    |                                               | |   *groups*          - OS groups to create. All parameters in the `Ansible      |          |
 |                                    |                                               |                         group module <ansible_group_module_>`_ are               |          |
 |                                    |                                               |                         supported.                                               |          |
@@ -1010,6 +1012,7 @@ node_templates:
 +------------------------------------+-----------------------------------------------+----------------------------------------------------------------------------------+----------+
 
 .. _ansible_user_module: http://docs.ansible.com/ansible/latest/user_module.html
+.. _gen_pass: http://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module
 .. _ansible_group_module: http://docs.ansible.com/ansible/latest/group_module.html
 
 

--- a/sample-configs/basic.config.red-hat.yml
+++ b/sample-configs/basic.config.red-hat.yml
@@ -112,7 +112,7 @@ node_templates:
           hostname_prefix: rhel72
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sda
       physical_interfaces:

--- a/sample-configs/basic.config.ubuntu.yml
+++ b/sample-configs/basic.config.ubuntu.yml
@@ -106,7 +106,7 @@ node_templates:
           profile: ubuntu-16.04-server-ppc64el
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:

--- a/sample-configs/mlag.config.red-hat.yml
+++ b/sample-configs/mlag.config.red-hat.yml
@@ -246,7 +246,7 @@ node_templates:
           profile: RHEL-7.3-20161019.0-Server-ppc64le-dvd1.iso
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:
@@ -288,7 +288,7 @@ node_templates:
           profile: RHEL-7.3-20161019.0-Server-ppc64le-dvd1.iso
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:
@@ -330,7 +330,7 @@ node_templates:
           profile: ubuntu-16.04-server-ppc64el
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:

--- a/sample-configs/mlag.config.ubuntu.yml
+++ b/sample-configs/mlag.config.ubuntu.yml
@@ -199,7 +199,7 @@ node_templates:
           profile: ubuntu-16.04-server-ppc64el
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:
@@ -241,7 +241,7 @@ node_templates:
           profile: ubuntu-16.04-server-ppc64el
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:
@@ -283,7 +283,7 @@ node_templates:
           profile: ubuntu-16.04-server-ppc64el
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:

--- a/sample-configs/non-func-comprehensive.config.yml
+++ b/sample-configs/non-func-comprehensive.config.yml
@@ -359,7 +359,7 @@ node_templates:
           profile: ubuntu-14.04.4-server-ppc64el
           users:
               - name: root
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
               - name: user1
                 groups: sudo
               - name: testuser1
@@ -434,7 +434,7 @@ node_templates:
           profile: RHEL-7.2-20151030.0-Server-ppc64le-dvd1
           users:
               - name: root
-                password_crypted: $6$STFB8U/AyA$sVhg5a/2RvDiXof9EhADVcUm/7Tq8T4m
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
               - name: user1
                 groups: sudo
               - name: testuser1

--- a/sample-configs/simple_flat.config.ubuntu.yml
+++ b/sample-configs/simple_flat.config.ubuntu.yml
@@ -109,7 +109,7 @@ node_templates:
           profile: ubuntu-16.04-server-ppc64el
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:
@@ -137,7 +137,7 @@ node_templates:
           profile: ubuntu-16.04-server-ppc64el
           users:
               - name: user1
-                password: passw0rd
+                password: $6$Utk.IILMG9.$EepS/sIgD4aA.qYQ3voZL9yI3/5Q4vv.p2s4sSmfCLAJlLAuaEmXDizDaBmJYGqHpobwpU2l4rJW.uUY4WNyv.
                 groups: sudo
           install_device: /dev/sdj
       physical_interfaces:


### PR DESCRIPTION
User passwords set in the config file 'node_templates: os: users:' must
be crypted. These dictionaries are passed to the Ansible 'user' module,
which no longer supports plaintext passwords. The config spec and sample
configs have been updated to show the requirement more clearly.