### PR TITLE
fix: Use Ansible version 2.4.3.0 instead of 2.5.0

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,7 +55,7 @@ sudo -E -H pip install --upgrade virtualenv
 virtualenv --no-wheel --system-site-packages deployenv
 source deployenv/bin/activate
 pip install \
-    'ansible==2.5.0' \
+    'ansible==2.4.3.0' \
     'orderedattrdict==1.5' \
     'pyroute2==0.5.0' \
     'jsonschema==2.6.0' \


### PR DESCRIPTION
In Ansible 2.5.0 'gather facts' requires 'dmidecode' software to be
installed on clients. This is considered a bug
(https://github.com/ansible/ansible/pull/38001). The previous Ansible
version, 2.4.3.0, is not exposed and seems to be working fine.