### PR TITLE
refactor: Allow OS profile to end with ".iso"

### DIFF
--- a/docs/Config-Specification.rst
+++ b/docs/Config-Specification.rst
@@ -855,7 +855,7 @@ node_templates:
 |             profile:               |         install_device: /dev/sda              |                                                                                  |          |
 |             install_device:        |         users:                                | |   *profile*         - Cobbler profile to use for OS installation. This         |          |
 |             users:                 |             - name: root                      |                         name usually should match the name of the                |          |
-|                 - name:            |               password: <crypted password>    |                         installation image (without the'.iso' extension).        |          |
+|                 - name:            |               password: <crypted password>    |                         installation image (with or without the'.iso' extension).|          |
 |                   password:        |             - name: user1                     | |   *install_device*  - Path to installation disk device.                        |          |
 |             groups:                |               password: <crypted password>    |                                                                                  |          |
 |                 - name:            |               groups: sudo,testgroup1         | | Optional keys:                                                                 |          |

--- a/scripts/python/cobbler_add_systems.py
+++ b/scripts/python/cobbler_add_systems.py
@@ -19,6 +19,7 @@ from __future__ import nested_scopes, generators, division, absolute_import, \
     with_statement, print_function, unicode_literals
 
 import xmlrpclib
+import re
 
 from lib.inventory import Inventory
 import lib.genesis as gen
@@ -41,7 +42,7 @@ def cobbler_add_systems():
         password_ipmi = inv.get_nodes_ipmi_password(index)
         ipv4_pxe = inv.get_nodes_pxe_ipaddr(0, index)
         mac_pxe = inv.get_nodes_pxe_mac(0, index)
-        cobbler_profile = inv.get_nodes_os_profile(index)
+        cobbler_profile = re.sub("[.]iso", "", inv.get_nodes_os_profile(index))
         raid1_enabled = False
 
         new_system_create = cobbler_server.new_system(token)


### PR DESCRIPTION
The OS profile defined in config.yml 'node_templates: - os: profile:'
value can match the installation image file exactly (including the
".iso" extension), or match the name excluding the ".iso" extension.