### PR TITLE
fix: Remove 'defaultuser' scripts from kickstart

### DIFF
--- a/os-images/config/RHEL-7-default.ks
+++ b/os-images/config/RHEL-7-default.ks
@@ -38,15 +38,6 @@ mkdir /root/.ssh
 chmod 700 /root/.ssh
 wget http://$http_server/authorized_keys -O /root/.ssh/authorized_keys
 chmod 600 /root/.ssh/authorized_keys
-# Add ssh keys to defaultuser
-mkdir /home/defaultuser/.ssh
-chown defaultuser:defaultuser /home/defaultuser/.ssh
-chmod 700 /home/defaultuser/.ssh
-wget http://$http_server/authorized_keys -O /home/defaultuser/.ssh/authorized_keys
-chown defaultuser:defaultuser /home/defaultuser/.ssh/authorized_keys
-chmod 600 /home/defaultuser/.ssh/authorized_keys
-# Enable passwordless sudo for defaultuser
-echo -e "defaultuser\tALL=NOPASSWD: ALL" > /etc/sudoers.d/defaultuser
 echo -e "[$distro]" > /etc/yum.repos.d/$(distro).repo
 echo -e "name=$distro" >> /etc/yum.repos.d/$(distro).repo
 echo -e "baseurl=http://$http_server/$distro/" >> /etc/yum.repos.d/$(distro).repo


### PR DESCRIPTION
The default kickstart no longer sets up SSH keys or passwordless sudo
for 'defaultuser'. If desired this can be accomplished through
post-deploy "software_bootstrap" scripts.