### PR TITLE
test: Use single tox python venv for all tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist = py27,bashate,flake8,ansible-lint,commit-message-validate,verify-copyri
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
+envdir = {toxinidir}/.tox/py27
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
There is no need to create separate, identical python virtual
environments for each tox test. On my laptop tox runs twice as fast by
by re-using single environment.