### PR TITLE
fix: Clean up deployer gateway NAT rules

### DIFF
--- a/scripts/pup
+++ b/scripts/pup
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ "$1" == "setup" ]] && [[ "$2" == "--networks" ]]; then
+if [[ "$1" == "setup" ]] && ([[ "$2" == "--networks" ]] ||
+        [[ "$2" == "--gateway" ]] || [[ "$2" == "-a" ]] ||
+        [[ "$2" == "--all" ]]); then
     sudo env "PATH=$PATH" gen.py $@
     exit
 fi

--- a/scripts/python/enable_deployer_gateway.py
+++ b/scripts/python/enable_deployer_gateway.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Copyright 2018 IBM Corp.
+#
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import nested_scopes, generators, division, absolute_import, \
+    with_statement, print_function, unicode_literals
+
+import subprocess
+from netaddr import IPNetwork
+
+import lib.logger as logger
+from lib.config import Config
+
+
+def enable_deployer_gateway(remove=False):
+    """Configure or remove NAT record for PXE Network gateway
+    Args:
+        remove (bool, optional): True(default)= configure NAT record
+                                     if it does not already exist.
+                                 False = Remove NAT record if it
+                                     exists.
+    """
+
+    cfg = Config()
+    log = logger.getlogger()
+
+    if not remove:
+        log.info('Configure NAT record for PXE network gateway')
+    else:
+        log.info('Remove NAT record for PXE network gateway')
+
+    type_ = cfg.get_depl_netw_client_type()
+    dev_label = cfg.get_depl_netw_client_device()
+    bridge_ipaddr = cfg.get_depl_netw_client_brg_ip()
+    netprefix = cfg.get_depl_netw_client_prefix()
+
+    for i, dev in enumerate(dev_label):
+        if cfg.get_depl_gateway() and type_[i] == "pxe":
+            _create_nat_gateway_rule(bridge_ipaddr[i] + "/" +
+                                     str(netprefix[i]), remove)
+
+
+def _create_nat_gateway_rule(network, remove=False):
+    log = logger.getlogger()
+    network = str(IPNetwork(network).cidr)
+    # Check if POSTROUTING nat rule already exists for client network
+    output = subprocess.check_output(
+        ['bash', '-c', 'iptables -L POSTROUTING -t nat']).splitlines()
+    for line in output:
+        if "MASQUERADE" in line and network in line:
+            log.debug('Found existing MASQUERADE NAT rule for {}: {}'.
+                      format(network, line))
+            if remove:
+                cmd = ("iptables -t nat -D POSTROUTING -p all -s {0} ! -d {0} "
+                       "-j MASQUERADE").format(network)
+                output = subprocess.check_output(['bash', '-c', cmd])
+                log.debug('Removed MASQUERADE NAT rule for {}: {}'.
+                          format(network, output))
+            else:
+                break
+    else:
+        if not remove:
+            # If no existing rules are found for network create one
+            cmd = ("iptables -t nat -A POSTROUTING -p all -s {0} ! -d {0} "
+                   "-j MASQUERADE").format(network)
+            output = subprocess.check_output(['bash', '-c', cmd])
+            log.debug('Created new MASQUERADE NAT rule for {}: {}'.
+                      format(network, output))
+
+
+if __name__ == '__main__':
+    logger.create()
+    enable_deployer_gateway()

--- a/scripts/python/enable_deployer_networks.py
+++ b/scripts/python/enable_deployer_networks.py
@@ -86,9 +86,6 @@ def enable_deployer_network():
                         bridge_ipaddr=bridge_ipaddr[i],
                         vlan=vlan[i],
                         type_=type_[i])
-        if cfg.get_depl_gateway() and type_[i] == "pxe":
-            _create_nat_gateway_rule(bridge_ipaddr[i] + "/" +
-                                     str(netprefix[i]))
 
 
 def _create_network(
@@ -487,22 +484,6 @@ def _wait_for_ifc_up(ifname, timespan=10):
         time.sleep(0.5)
     LOG.info('Timeout waiting for interface {} to come up'.format(ifname))
     return False
-
-
-def _create_nat_gateway_rule(network):
-    # Check if POSTROUTING nat rule already exists for client network
-    output = subprocess.check_output(
-        ['bash', '-c', 'iptables -L POSTROUTING -t nat']).splitlines()
-    for line in output:
-        if "MASQUERADE" in line and network in line:
-            LOG.debug('Found existing MASQUERADE NAT rule for {}: {}'.format(network, line))
-            break
-    else:
-        # If no existing rules are found for network create one
-        cmd = ("iptables -t nat -A POSTROUTING -p all -s {0} ! -d {0} "
-               "-j MASQUERADE").format(network)
-        output = subprocess.check_output(['bash', '-c', cmd])
-        LOG.debug('Created new MASQUERADE NAT rule for {}: {}'.format(network, output))
 
 
 if __name__ == '__main__':

--- a/scripts/python/gen.py
+++ b/scripts/python/gen.py
@@ -26,6 +26,7 @@ import getpass
 import subprocess
 
 import enable_deployer_networks
+import enable_deployer_gateway
 import validate_cluster_hardware
 import configure_mgmt_switches
 import download_os_images
@@ -101,6 +102,24 @@ class Gen(object):
                   format(COL.yellow, exc, COL.endc))
         else:
             print('Successfully completed deployer network setup\n')
+
+    def _enable_deployer_gateway(self):
+        print(COL.scroll_ten, COL.up_ten)
+        print('{}Setting up PXE network gateway and NAT record{}\n'.
+              format(COL.header1, COL.endc))
+        try:
+            enable_deployer_gateway.enable_deployer_gateway()
+        except UserCriticalException as exc:
+            print('{}Critical error occured while setting up PXE network '
+                  'gateway and NAT record:\n{}{}'.
+                  format(COL.red, exc, COL.endc))
+            sys.exit(1)
+        except UserException as exc:
+            print('{}Error occured while setting up PXE network gateway and '
+                  'NAT record: \n{}{}'.
+                  format(COL.yellow, exc, COL.endc))
+        else:
+            print('Successfully completed PXE network gateway setup\n')
 
     def _create_container(self):
         print(COL.scroll_ten, COL.up_ten)
@@ -471,9 +490,17 @@ class Gen(object):
                 print(
                     'Fail: Invalid subcommand in container', file=sys.stderr)
                 sys.exit(1)
+
             self._check_root_user(cmd)
+
+            if self.args.all:
+                self.args.networks = True
+                self.args.gateway = True
+
             if self.args.networks:
                 self._create_deployer_networks()
+            if self.args.gateway:
+                self._enable_deployer_gateway()
 
         if cmd == argparse_gen.Cmd.CONFIG.value:
             if gen.is_container():

--- a/scripts/python/lib/argparse_gen.py
+++ b/scripts/python/lib/argparse_gen.py
@@ -133,7 +133,7 @@ def get_args(parser_args=False):
     parser_setup.add_argument(
         '-a', '--all',
         action='store_true',
-        help='TBD')
+        help='Run all cluster setup steps')
 
     # 'config' subcommand arguments
     parser_config.set_defaults(

--- a/scripts/python/lib/argparse_teardown.py
+++ b/scripts/python/lib/argparse_teardown.py
@@ -84,9 +84,9 @@ def get_args(parser_args=False):
         deployer=True)
 
     parser_deployer.add_argument(
-        '--networks',
+        '--container',
         action='store_true',
-        help=DEPLOYER_NETWORKS_HELP)
+        help='Destroy the {} container.'.format(PROJECT))
 
     parser_deployer.add_argument(
         '--gateway',
@@ -94,9 +94,9 @@ def get_args(parser_args=False):
         help='Delete deployer network gateway and NAT record')
 
     parser_deployer.add_argument(
-        '--container',
+        '--networks',
         action='store_true',
-        help='Destroy the {} container.'.format(PROJECT))
+        help=DEPLOYER_NETWORKS_HELP)
 
     parser_deployer.add_argument(
         '-a', '--all',

--- a/scripts/python/teardown.py
+++ b/scripts/python/teardown.py
@@ -22,8 +22,9 @@ from __future__ import nested_scopes, generators, division, absolute_import, \
 
 import sys
 
-import teardown_deployer_networks
 import teardown_deployer_container
+import enable_deployer_gateway
+import teardown_deployer_networks
 import lib.argparse_teardown as argparse_teardown
 import lib.logger as logger
 import configure_data_switches
@@ -42,11 +43,11 @@ class Teardown(object):
     def _destroy_deployer_container(self):
         teardown_deployer_container.teardown_deployer_container()
 
+    def _teardown_deployer_gateway(self):
+        enable_deployer_gateway.enable_deployer_gateway(remove=True)
+
     def _teardown_deployer_networks(self):
         teardown_deployer_networks.teardown_deployer_network()
-
-    def _teardown_deployer_gateway(self):
-        sys.exit('Teardown deployer gateway not implemented')
 
     def _teardown_switch_data(self):
         configure_data_switches.deconfigure_data_switch()
@@ -60,12 +61,12 @@ class Teardown(object):
         # Determine which subcommand was specified
         try:
             if self.args.deployer:
-                if self.args.networks:
-                    self._teardown_deployer_networks()
                 if self.args.container:
                     self._destroy_deployer_container()
                 if self.args.gateway:
                     self._teardown_deployer_gateway()
+                if self.args.networks:
+                    self._teardown_deployer_networks()
         except AttributeError:
             pass
 

--- a/scripts/teardown
+++ b/scripts/teardown
@@ -16,12 +16,13 @@
 # limitations under the License.
 
 if [[ "$1" == "deployer" ]]; then
-    if [[ "$2" == "--networks" ]]; then
+    if [[ "$2" == "--networks" ]] || [[ "$2" == "--gateway" ]]; then
         sudo env "PATH=$PATH" teardown.py $@
     elif [[ "$2" == "--all" ]] || [[ "$2" == "--al" ]] || \
             [[ "$2" == "--a" ]] || [[ "$2" == "-a" ]]; then
-        sudo env "PATH=$PATH" teardown.py deployer --networks
         teardown.py deployer --container
+        sudo env "PATH=$PATH" teardown.py deployer --gateway
+        sudo env "PATH=$PATH" teardown.py deployer --networks
     else
         teardown.py $@
     fi


### PR DESCRIPTION
Enable 'pup setup --gateway' and 'teardown deployer --gateway'.

Fix logic to detect if existing rule is in place to prevent redundant
entries.