### PR TITLE
fix: Write test inventory.yml to power-up/logs

### DIFF
--- a/scripts/python/gen.py
+++ b/scripts/python/gen.py
@@ -152,7 +152,8 @@ class Gen(object):
         print('{}Validating cluster configuration file{}\n'.
               format(COL.header1, COL.endc))
         dbase = DatabaseConfig()
-        nodes = InventoryNodes()
+        inv_path = gen.GEN_LOGS_PATH + gen.INV_FILE_NAME
+        nodes = InventoryNodes(inv_path)
         try:
             dbase.validate_config(self.args.config_file)
             nodes.create_nodes()

--- a/scripts/python/lib/inv_nodes.py
+++ b/scripts/python/lib/inv_nodes.py
@@ -31,10 +31,10 @@ class InventoryNodes(object):
     SWITCH_NOT_FOUND = \
         "Node template '%s' did not have corresponding management switch '%s'"
 
-    def __init__(self):
+    def __init__(self, inv_path=None):
         self.log = logger.getlogger()
 
-        self.inv = Inventory()
+        self.inv = Inventory(inv_path)
 
     def __del__(self):
         self.inv.update_nodes()


### PR DESCRIPTION
Move test creation of inventory.yml to power-up/logs so as to not
interact with symlink creation.