### PR TITLE
fix: Call 'setup --all' from 'pup deploy'

### DIFF
--- a/scripts/pup
+++ b/scripts/pup
@@ -40,7 +40,7 @@ if [[ "$1" == "deploy" ]] && ([[ "$2" == "-a" ]] || [[ "$2" == "--all" ]] || \
         exit
     fi
 
-    sudo env "PATH=$PATH" gen.py setup --networks $@
+    sudo env "PATH=$PATH" gen.py setup --all $@
     if [ $? -ne 0 ]; then
         exit
     fi


### PR DESCRIPTION
When running 'pup deploy' 'setup --all' need to be called in order to
include deployer gateway configuration.