### PR TITLE
fix: Update python 'cryptography' module version

### DIFF
--- a/scripts/venv_install.sh
+++ b/scripts/venv_install.sh
@@ -29,6 +29,8 @@ pip install \
     'pyasn1==0.4.2' \
     'pysnmp==4.4.4' \
     'pyaml==17.12.1' \
+    'pyOpenSSL==17.5.0' \
+    'cryptography==2.2.2' \
     'paramiko==2.4.1' \
     'tabulate==0.8.2' \
     'gitpython==2.1.9'


### PR DESCRIPTION
Pip is reporting that "paramiko 2.4.1 has requirement cryptography>=1.5,
but you'll have cryptography 1.2.3 which is incompatible." The latest
'cryptography' version requires 'pyOpenSSL==17.5.0'.