### PR TITLE
fix: Retry IPMI set bootdev on 'AssertionError'

### DIFF
--- a/scripts/python/ipmi_set_bootdev.py
+++ b/scripts/python/ipmi_set_bootdev.py
@@ -63,9 +63,9 @@ def ipmi_set_bootdev(bootdev, persist=False, client_list=None):
                 status = ipmi_cmd.set_bootdev(bootdev, persist)
             except (pyghmi_exception.IpmiException, AssertionError) as error:
                 msg = (
-                    'set_bootdev failed (device=%s persist=%s), retrying once - '
-                    'Rack: %s - IP: %s, %s' %
-                    (bootdev, persist, rack_id, ipv4, str(error)))
+                    'set_bootdev failed (device=%s persist=%s), retrying once '
+                    '- Rack: %s - IP: %s, (%s) %s' %
+                    (bootdev, persist, rack_id, ipv4, type(error), str(error)))
                 log.warning(msg)
                 del ipmi_cmd
                 ipmi_cmd = ipmi_command.Command(
@@ -78,8 +78,9 @@ def ipmi_set_bootdev(bootdev, persist=False, client_list=None):
                         AssertionError) as error:
                     msg = (
                         'set_bootdev failed (device=%s persist=%s) - '
-                        'Rack: %s - IP: %s, %s' %
-                        (bootdev, persist, rack_id, ipv4, str(error)))
+                        'Rack: %s - IP: %s, (%s) %s' %
+                        (bootdev, persist, rack_id, ipv4, type(error),
+                         str(error)))
                     log.error(msg)
                     raise UserException(msg)
 
@@ -98,8 +99,8 @@ def ipmi_set_bootdev(bootdev, persist=False, client_list=None):
             except (pyghmi_exception.IpmiException, AssertionError) as error:
                 msg = (
                     'get_bootdev failed - '
-                    'Rack: %s - IP: %s, %s' %
-                    (rack_id, ipv4, str(error)))
+                    'Rack: %s - IP: %s, (%s) %s' %
+                    (rack_id, ipv4, type(error), str(error)))
                 log.error(msg)
                 raise UserException(msg)
 

--- a/scripts/python/ipmi_set_bootdev.py
+++ b/scripts/python/ipmi_set_bootdev.py
@@ -61,7 +61,7 @@ def ipmi_set_bootdev(bootdev, persist=False, client_list=None):
         if ipv4_pxe in client_list:
             try:
                 status = ipmi_cmd.set_bootdev(bootdev, persist)
-            except pyghmi_exception.IpmiException as error:
+            except (pyghmi_exception.IpmiException, AssertionError) as error:
                 msg = (
                     'set_bootdev failed (device=%s persist=%s), retrying once - '
                     'Rack: %s - IP: %s, %s' %
@@ -74,7 +74,8 @@ def ipmi_set_bootdev(bootdev, persist=False, client_list=None):
                     password=password)
                 try:
                     status = ipmi_cmd.set_bootdev(bootdev, persist)
-                except pyghmi_exception.IpmiException as error:
+                except (pyghmi_exception.IpmiException,
+                        AssertionError) as error:
                     msg = (
                         'set_bootdev failed (device=%s persist=%s) - '
                         'Rack: %s - IP: %s, %s' %
@@ -94,7 +95,7 @@ def ipmi_set_bootdev(bootdev, persist=False, client_list=None):
 
             try:
                 status = ipmi_cmd.get_bootdev()
-            except pyghmi_exception.IpmiException as error:
+            except (pyghmi_exception.IpmiException, AssertionError) as error:
                 msg = (
                     'get_bootdev failed - '
                     'Rack: %s - IP: %s, %s' %


### PR DESCRIPTION
The 'ipmi_set_bootdev' function already excepts
'pyghmi_exception.IpmiException' and retries once. Now 'AssertionError'
is also excepted to allow a retry.