### PR TITLE
fix: Disable Cobbler 'manage_genders' by default

### DIFF
--- a/scripts/python/cobbler_install.py
+++ b/scripts/python/cobbler_install.py
@@ -128,6 +128,12 @@ def cobbler_install():
                        'https://cobbler.github.io',
                        'http://cobbler.github.io')
 
+    # Disable 'manage_genders'
+    original = '    \"manage_dns\"                          \: \[0,\"bool\"\],'
+    replace = ('    "manage_dns"                          : [0,"bool"],\n'
+               '    "manage_genders"                      : [0,"bool"],')
+    util.replace_regex(COBBLER_SETTINGS_PY, original, replace)
+
     # Run cobbler make install
     util.bash_cmd('cd %s; make install' % install_dir)
 


### PR DESCRIPTION
Cobbler commit e1c6aa5 backported a feature to manage '/etc/genders'.
This commit does not include a default setting for 'manage_genders' to
be used when it is not included in the config file.

This commit should be reverted when Cobbler 'release28' branch is fixed.