### PR TITLE
Revert "fix: Disable Cobbler 'manage_genders' by default (#125)"

### DIFF
--- a/scripts/python/cobbler_install.py
+++ b/scripts/python/cobbler_install.py
@@ -129,12 +129,6 @@ def cobbler_install(config_path=None):
                        'https://cobbler.github.io',
                        'http://cobbler.github.io')
 
-    # Disable 'manage_genders'
-    original = '    \"manage_dns\"                          \: \[0,\"bool\"\],'
-    replace = ('    "manage_dns"                          : [0,"bool"],\n'
-               '    "manage_genders"                      : [0,"bool"],')
-    util.replace_regex(COBBLER_SETTINGS_PY, original, replace)
-
     # Run cobbler make install
     util.bash_cmd('cd %s; make install' % install_dir)
 


### PR DESCRIPTION
This reverts commit ce030abd87197db7ff37d9c745e770aa49466d3c.

Fix was accepted in upstream Cobbler repo
(https://github.com/cobbler/cobbler/pull/1896).