### PR TITLE
fix: Create user '.ssh' directory if needed

### DIFF
--- a/scripts/python/lib/container.py
+++ b/scripts/python/lib/container.py
@@ -251,8 +251,8 @@ class Container(object):
                 not os.path.isfile(self.PUBLIC_SSH_KEY_FILE)):
             key = RSA.generate(self.RSA_BIT_LENGTH)
             # Create user .ssh directory if needed
-            if not os.path.exists('~/.ssh'):
-                os.mkdir('~/.ssh', 0o700)
+            if not os.path.exists(os.path.expanduser('~/.ssh')):
+                os.mkdir(os.path.expanduser('~/.ssh'), 0o700)
             # Create private ssh key
             with open(self.PRIVATE_SSH_KEY_FILE, 'w') as ssh_key:
                 ssh_key.write(key.exportKey())

--- a/scripts/python/lib/container.py
+++ b/scripts/python/lib/container.py
@@ -250,6 +250,9 @@ class Container(object):
         if (not os.path.isfile(self.PRIVATE_SSH_KEY_FILE) and
                 not os.path.isfile(self.PUBLIC_SSH_KEY_FILE)):
             key = RSA.generate(self.RSA_BIT_LENGTH)
+            # Create user .ssh directory if needed
+            if not os.path.exists('~/.ssh'):
+                os.mkdir('~/.ssh', 0o700)
             # Create private ssh key
             with open(self.PRIVATE_SSH_KEY_FILE, 'w') as ssh_key:
                 ssh_key.write(key.exportKey())

--- a/scripts/python/remove_client_host_keys.py
+++ b/scripts/python/remove_client_host_keys.py
@@ -34,7 +34,8 @@ def remove_client_host_keys(config_path=None):
 
     for ipaddr in inv.yield_nodes_pxe_ipaddr():
         log.info("Remove any stale ssh host keys for {}".format(ipaddr))
-        util.bash_cmd("ssh-keygen -R {}".format(ipaddr))
+        if os.path.isfile(os.path.expanduser('~/.ssh/known_hosts')):
+            util.bash_cmd("ssh-keygen -R {}".format(ipaddr))
         playbooks_known_hosts = (os.path.join(gen.get_playbooks_path(),
                                               'known_hosts'))
         if os.path.isfile(playbooks_known_hosts):


### PR DESCRIPTION
POWER-Up will automatically create an SSH private/public key pair if it
does not already exist. If a '.ssh' directory does not exist in the
user's home directory it needs to be created before the SSH key pair can
be written to file.