### PR TITLE
fix: Use IP route to get installer IP address

### DIFF
--- a/software/paie52_ansible/install_anaconda.yml
+++ b/software/paie52_ansible/install_anaconda.yml
@@ -1,11 +1,18 @@
 ---
+- name: Get route to client
+  command: "{{ hostvars['localhost']['python_executable_local'] }} \
+  {{ hostvars['localhost']['scripts_path_local'] }}/python/ip_route_get_to.py \
+  {{ inventory_hostname }}"
+  delegate_to: localhost
+  register: host_ip
+
 - name: Download Anaconda
   get_url:
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_id }}"
     mode: 0744
     checksum: md5:e894dcc547a1c7d67deb04f6bba7223a
-    url: http://10.0.20.21/anaconda/Anaconda2-5.1.0-Linux-ppc64le.sh
+    url: "http://{{ host_ip.stdout }}/anaconda/Anaconda2-5.1.0-Linux-ppc64le.sh"
     dest: "{{ ansible_env.HOME }}"
 
 - name: Install Anaconda

--- a/software/paie52_ansible/install_cudnn.yml
+++ b/software/paie52_ansible/install_cudnn.yml
@@ -1,6 +1,14 @@
 ---
+- name: Get route to client
+  command: "{{ hostvars['localhost']['python_executable_local'] }} \
+  {{ hostvars['localhost']['scripts_path_local'] }}/python/ip_route_get_to.py \
+  {{ inventory_hostname }}"
+  delegate_to: localhost
+  register: host_ip
+
 - name: Install the cuDNN v7.1.2 packages
-  shell: "curl -G http://10.0.20.21/cudnn/cudnn-9.2-linux-ppc64le-v7.1.tgz \
+  shell: "curl -G \
+  http://{{ host_ip.stdout }}/cudnn/cudnn-9.2-linux-ppc64le-v7.1.tgz \
   | tar -C /usr/local --no-same-owner -xzv"
   args:
     warn: no

--- a/software/paie52_ansible/install_nccl.yml
+++ b/software/paie52_ansible/install_nccl.yml
@@ -1,6 +1,14 @@
 ---
+- name: Get route to client
+  command: "{{ hostvars['localhost']['python_executable_local'] }} \
+  {{ hostvars['localhost']['scripts_path_local'] }}/python/ip_route_get_to.py \
+  {{ inventory_hostname }}"
+  delegate_to: localhost
+  register: host_ip
+
 - name: Install NVIDIA Collective Communications Library
-  shell: "curl -G http://10.0.20.21/nccl2/nccl_2.2.12-1+cuda9.2_ppc64le.tgz \
+  shell: "curl -G \
+  http://{{ host_ip.stdout }}/nccl2/nccl_2.2.12-1+cuda9.2_ppc64le.tgz \
   | tar -C /usr/local --no-same-owner -xzv"
   args:
     warn: no

--- a/software/paie52_ansible/run.yml
+++ b/software/paie52_ansible/run.yml
@@ -1,4 +1,9 @@
 ---
+- name: Gather localhost facts
+  hosts: localhost
+  gather_facts: True
+  tasks: []
+
 - hosts: all
   handlers:
     - import_tasks: reboot.yml


### PR DESCRIPTION
Several of the paie52 install tasks reference an IP address to reach the
installer node. The 'ip_route_get_to.py' script is used to dynamically
insert an IP with a route to each individual client node.