### PR TITLE
fix: Append Anaconda install dir to PATH

### DIFF
--- a/software/paie52_ansible/install_anaconda.yml
+++ b/software/paie52_ansible/install_anaconda.yml
@@ -1,4 +1,22 @@
 ---
+- name: Set installation directory variable
+  set_fact:
+    install_dir: "{{ ansible_env.HOME }}/anaconda2"
+
+- name: Check if anaconda2 directory already exists
+  stat:
+    path: "{{ install_dir }}"
+  register: anaconda2_dir
+
+- name: Set install args variable
+  set_fact:
+    args: ""
+
+- name: If install directory exists use update arg
+  set_fact:
+    args: -u
+  when: anaconda2_dir.stat.isdir is defined and anaconda2_dir.stat.isdir
+
 - name: Download Anaconda
   get_url:
     owner: "{{ ansible_user_id }}"
@@ -9,6 +27,13 @@
     dest: "{{ ansible_env.HOME }}"
 
 - name: Install Anaconda
-  shell: ~/Anaconda2-5.1.0-Linux-ppc64le.sh -b -p ~/Anaconda/
+  shell: "{{ ansible_env.HOME }}/Anaconda2-5.1.0-Linux-ppc64le.sh \
+          -b -p {{ install_dir }} {{ args }}"
   args:
     executable: /bin/bash
+
+- name: Add Anaconda2 install location to PATH in bashrc
+  lineinfile:
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    regexp: ".*PATH={{ install_dir}}/bin.*"
+    line: "export PATH={{ install_dir}}/bin:$PATH"

--- a/software/paie52_ansible/install_anaconda.yml
+++ b/software/paie52_ansible/install_anaconda.yml
@@ -35,5 +35,5 @@
 - name: Add Anaconda2 install location to PATH in bashrc
   lineinfile:
     path: "{{ ansible_env.HOME }}/.bashrc"
-    regexp: ".*PATH={{ install_dir}}/bin.*"
-    line: "export PATH={{ install_dir}}/bin:$PATH"
+    regexp: ".*PATH={{ install_dir }}/bin.*"
+    line: "export PATH={{ install_dir }}/bin:$PATH"


### PR DESCRIPTION
Add Anaconda2 install location to PATH in user's '.bashrc'.

Change install directory to default '~/anaconda2'.

If '~/anaconda2' directory already exists use '-u' argument with the
installation script to update the existing files.