### PR TITLE
refactor: Improve software inventory prompts

### DIFF
--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -310,7 +310,7 @@ def _validate_ansible_ping(software_hosts_file_path):
     return True
 
 
-def _validate_software_inventory(software_hosts_file_path):
+def validate_software_inventory(software_hosts_file_path):
     """Validate Ansible software inventory
 
     Args:
@@ -363,7 +363,7 @@ def get_ansible_inventory():
         print("--------------------------------")
         print(_get_groups_hosts_string(dynamic_inventory))
         print("--------------------------------")
-        _validate_software_inventory(software_hosts_file_path)
+        validate_software_inventory(dynamic_inventory)
         if click.confirm('Do you want to use this inventory?'):
             print("Using Ansible Dynamic Inventory")
             inventory_choice = dynamic_inventory_path
@@ -404,29 +404,29 @@ def get_ansible_inventory():
                     continue
 
             # Menu items can modified to show validation results
-            menu_items = ['Edit inventory file',
-                          'Use inventory file as-is',
+            menu_items = ['Continue with current inventory',
+                          'Edit inventory file',
                           'Exit program']
 
             # Validate software inventory
             print("Validating software inventory...")
-            if _validate_software_inventory(software_hosts_file_path):
+            if validate_software_inventory(software_hosts_file_path):
                 print(bold("Validation passed!"))
             else:
                 print(bold("Validation FAILED!"))
-                menu_items[1] = ("Use inventory file as-is - "
+                menu_items[0] = ("Continue with inventory as-is - "
                                  "WARNING: Validated failed")
 
-            # If validation fails or user opts not to use as-is
+            # Prompt user
             choice, item = get_selection(menu_items)
             print(f'Choice: {choice} Item: {item}')
             if choice == "1":
-                click.edit(filename=software_hosts_file_path)
-            elif choice == "2":
                 print("Using '{}' as inventory"
                       .format(software_hosts_file_path))
                 inventory_choice = software_hosts_file_path
                 break
+            elif choice == "2":
+                click.edit(filename=software_hosts_file_path)
             elif choice == "3":
                 sys.exit(1)
 

--- a/software/paie52.py
+++ b/software/paie52.py
@@ -32,7 +32,7 @@ import code
 import lib.logger as logger
 from repos import PowerupRepo, PowerupRepoFromDir, PowerupRepoFromRepo, \
     PowerupRepoFromRpm, setup_source_file, PowerupFileFromDisk
-from software_hosts import get_ansible_inventory
+from software_hosts import get_ansible_inventory, validate_software_inventory
 from lib.utilities import sub_proc_display, sub_proc_exec, heading1, get_url, Color, \
     get_selection, get_yesno, get_dir, get_file_path, get_src_path, rlinput, bold
 from lib.genesis import GEN_SOFTWARE_PATH, get_ansible_playbook_path, \
@@ -93,6 +93,8 @@ class software(object):
                       'CUDA nccl2 content': 'nccl_2.2.1[2-9]-1+cuda9.[2-9]_ppc64le.tgz',
                       'Spectrum conductor content': 'cws-2.[2-9].[0-9].[0-9]_ppc64le.bin',
                       'Spectrum DLI content': 'dli-1.[1-9].[0-9].[0-9]_ppc64le.bin'}
+        if 'ansible_inventory' not in self.sw_vars:
+            self.sw_vars['ansible_inventory'] = None
 
         self.log.debug(f'software variables: {self.sw_vars}')
 
@@ -738,25 +740,33 @@ class software(object):
                            f'rc: {rc} err: {err}')
 
     def init_clients(self):
-        ansible_inventory = get_ansible_inventory()
+        self.sw_vars['ansible_inventory'] = get_ansible_inventory()
         cmd = ('{} -i {} '
                '{}/init_clients.yml --ask-become-pass'
-               .format(get_ansible_playbook_path(), ansible_inventory,
+               .format(get_ansible_playbook_path(),
+                       self.sw_vars['ansible_inventory'],
                        GEN_SOFTWARE_PATH))
         resp, err, rc = sub_proc_exec(cmd)
-        # cmd = ('ssh -t -i ~/.ssh/gen root@10.0.20.22 '
-        #        '/opt/DL/license/bin/accept-powerai-license.sh')
-        # resp = sub_proc_display(cmd)
-        # print(resp)
         print('All done')
 
     def install(self):
-        ansible_inventory = get_ansible_inventory()
+        if self.sw_vars['ansible_inventory'] is None:
+            self.sw_vars['ansible_inventory'] = get_ansible_inventory()
+        else:
+            print("Validating software inventory '{}'..."
+                  .format(self.sw_vars['ansible_inventory']))
+            if validate_software_inventory(self.sw_vars['ansible_inventory']):
+                print(bold("Validation passed!"))
+            else:
+                print(bold("Validation FAILED!"))
+                self.sw_vars['ansible_inventory'] = get_ansible_inventory()
+
         install_tasks = yaml.load(open(GEN_SOFTWARE_PATH +
                                        'paie52_install_procedure.yml'))
         for task in install_tasks:
             heading1(f"Client Node Action: {task['description']}")
-            _run_ansible_tasks(task['tasks'], ansible_inventory)
+            _run_ansible_tasks(task['tasks'],
+                               self.sw_vars['ansible_inventory'])
         print('Done')
 
 


### PR DESCRIPTION
Change the order and wording of the software inventory configuration
prompts so the "good" path to continue is the first option.

If a user has already completed the software inventory setup routine in
'--init-clients' then '--install' only needs to run validation. If
validation passes installation can continue without prompting, else if
validation fails the user will be presented with the software inventory
setup routine.