### PR TITLE
fix: Limit host list in 'lookup_interface_names'

### DIFF
--- a/playbooks/lookup_interface_names.yml
+++ b/playbooks/lookup_interface_names.yml
@@ -57,7 +57,7 @@
     - name: Combine client node tables
       set_fact:
         set_macs_all: "{{ set_macs_all| combine(hostvars[item]['set_macs']) }}"
-      with_items: "{{ hostvars }}"
+      with_items: "{{ groups['client_nodes'] }}"
       when: hostvars[item]['set_macs'] is defined
 
     - name: Call 'inv_set_interface_names.py' with lookup data


### PR DESCRIPTION
The playbook 'lookup_interface_names.yml' is used to merge dictionaries
mapping all client node MACs to interface names.  It's possible for
environmental variables on localhost to cause jinja template errors when
they container "{{" "}}" characters. The play was run on all hosts but
only needs to be run on client nodes so this fix limits iteration over
client nodes only.