### PR TITLE
fix: Update Ansible pip package to '2.5.5' (#163)

### DIFF
--- a/scripts/venv_install.sh
+++ b/scripts/venv_install.sh
@@ -19,7 +19,7 @@ python3.6 -m venv ${1}pup-venv
 source ${1}pup-venv/bin/activate
 pip install --upgrade pip
 pip install \
-    'ansible==2.5.2' \
+    'ansible==2.5.5' \
     'orderedattrdict==1.5' \
     'pyroute2==0.5.0' \
     'jsonschema==2.6.0' \


### PR DESCRIPTION
Ansible version '2.5.2' has a bug that will display "[ERROR]:" when
running a dynamic inventory script
(https://github.com/ansible/ansible/issues/39007) due to an appended new
line character. This issue is resolved by
https://github.com/ansible/ansible/pull/39019 which is included in
Ansible version '2.5.5'.