### PR TITLE
feat: Improve 'software --install' messages

### DIFF
--- a/software/paie52.py
+++ b/software/paie52.py
@@ -788,8 +788,14 @@ def _run_ansible_tasks(tasks_path, ansible_inventory, extra_args=''):
     run = True
     while run:
         log.info(f'Running Ansible tasks found in \'{tasks_path}\' ...')
+        if 'notify: Reboot' in open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read():
+            print(bold('\nThis step requires changed systems to reboot! '
+                       '(16 minute timeout)'))
+        if '--ask-become-pass' in cmd:
+            print('\nClient password required for privilege escalation')
         resp, err, rc = sub_proc_exec(cmd, shell=True)
         log.debug(f"cmd: {cmd}\nresp: {resp}\nerr: {err}\nrc: {rc}")
+        print("") # line break
         if rc != 0:
             log.warning("Ansible tasks failed!")
             if resp != '':


### PR DESCRIPTION
Print a message if a play include tasks that may result in client node
reboots.

Print a message indicating that the SUDO prompt requires the client node
password.