### PR TITLE
refactor: Prevent multiple reboots from udev rules

### DIFF
--- a/software/paie52_ansible/disable_udev_mem_auto_onlining.yml
+++ b/software/paie52_ansible/disable_udev_mem_auto_onlining.yml
@@ -2,6 +2,7 @@
 - name: Enable 40-redhat.rules
   copy:
     remote_src: yes
+    force: no
     src: /lib/udev/rules.d/40-redhat.rules
     dest: /etc/udev/rules.d/
   become: yes
@@ -9,7 +10,7 @@
 - name: Disable udev Memory Auto-Onlining Rule
   replace:
     path: /etc/udev/rules.d/40-redhat.rules
-    regexp: '(SUBSYSTEM=="memory")'
+    regexp: '^(SUBSYSTEM=="memory")'
     replace: '#\1'
   become: yes
   notify: Reboot


### PR DESCRIPTION
When re-running the playbook to disable udev memory auto onlining
there's no need to reboot client nodes if nothing has changed. With a
few modifications to the task Ansible will be able to use built-in
"changed" logic to prevent multiple reboots.