### PR TITLE
fix: Update Cuda directory links in Ansible tasks

### DIFF
--- a/software/paie52_ansible/install_cudnn.yml
+++ b/software/paie52_ansible/install_cudnn.yml
@@ -8,7 +8,7 @@
 
 - name: Install the cuDNN v7.1.2 packages
   shell: "curl -G \
-  http://{{ host_ip.stdout }}/cudnn/cudnn-9.2-linux-ppc64le-v7.1.tgz \
+  http://{{ host_ip.stdout }}/cuda-dnn/cudnn-9.2-linux-ppc64le-v7.1.tgz \
   | tar -C /usr/local --no-same-owner -xzv"
   args:
     warn: no

--- a/software/paie52_ansible/install_nccl.yml
+++ b/software/paie52_ansible/install_nccl.yml
@@ -8,7 +8,7 @@
 
 - name: Install NVIDIA Collective Communications Library
   shell: "curl -G \
-  http://{{ host_ip.stdout }}/nccl2/nccl_2.2.12-1+cuda9.2_ppc64le.tgz \
+  http://{{ host_ip.stdout }}/cuda-nccl2/nccl_2.2.13-1+cuda9.2_ppc64le.tgz \
   | tar -C /usr/local --no-same-owner -xzv"
   args:
     warn: no


### PR DESCRIPTION
Cuda directories (cuda-dnn and cuda-nccl2) need to be updated in Ansible
install tasks due to commit a8a1916.