### PR TITLE
feat: Facilitate single PowerAI license acceptance

### DIFF
--- a/software/paie52.py
+++ b/software/paie52.py
@@ -772,7 +772,7 @@ class software(object):
                                        'paie52_install_procedure.yml'))
         for task in install_tasks:
             heading1(f"Client Node Action: {task['description']}")
-            if task['description'] == "Run License Script":
+            if task['description'] == "Run PowerAI License Script":
                 _interactive_powerai_license_accept(
                     self.sw_vars['ansible_inventory'])
             _run_ansible_tasks(task['tasks'],

--- a/software/paie52.py
+++ b/software/paie52.py
@@ -28,6 +28,7 @@ from shutil import copy2, Error
 import time
 import yaml
 import code
+import json
 
 import lib.logger as logger
 from repos import PowerupRepo, PowerupRepoFromDir, PowerupRepoFromRepo, \
@@ -771,6 +772,9 @@ class software(object):
                                        'paie52_install_procedure.yml'))
         for task in install_tasks:
             heading1(f"Client Node Action: {task['description']}")
+            if task['description'] == "Run License Script":
+                _interactive_powerai_license_accept(
+                    self.sw_vars['ansible_inventory'])
             _run_ansible_tasks(task['tasks'],
                                self.sw_vars['ansible_inventory'])
         print('Done')
@@ -807,6 +811,39 @@ def _run_ansible_tasks(tasks_path, ansible_inventory, extra_args=''):
         else:
             log.info("Ansible tasks ran successfully")
             run = False
+    return rc
+
+
+def _interactive_powerai_license_accept(ansible_inventory):
+    log = logger.getlogger()
+    cmd = (f'ansible-inventory --inventory {ansible_inventory} --list')
+    resp, err, rc = sub_proc_exec(cmd, shell=True)
+    inv = json.loads(resp)
+    hostname, hostvars = inv['_meta']['hostvars'].popitem()
+
+    cmd = (f'ssh -t {hostvars["ansible_user"]}@{hostname} '
+           f'-i {hostvars["ansible_ssh_private_key_file"]} '
+           f'{hostvars["ansible_ssh_common_args"]} '
+            '/opt/DL/license/bin/check-powerai-license.sh')
+    rc = sub_proc_display(cmd)
+
+    if rc == 0:
+        print(f'PowerAI license already accepted on {hostname}')
+    else:
+        print(bold('Manual PowerAI license acceptance required on at least '
+                   'one client!'))
+        rlinput(f'Press Enter to run interactive license script on {hostname}')
+        cmd = (f'ssh -t {hostvars["ansible_user"]}@{hostname} '
+               f'-i {hostvars["ansible_ssh_private_key_file"]} '
+               f'{hostvars["ansible_ssh_common_args"]} '
+                'sudo /opt/DL/license/bin/accept-powerai-license.sh')
+        rc = sub_proc_display(cmd)
+        if rc == 0:
+            print('\nLicense accepted. Acceptance script will be run quietly '
+                  'on remaining servers.')
+        else:
+            log.error("PowerAI license acceptance required to continue!")
+            sys.exit('Exiting')
     return rc
 
 

--- a/software/paie52_ansible/powerai_license_accept.yml
+++ b/software/paie52_ansible/powerai_license_accept.yml
@@ -1,10 +1,4 @@
 ---
-- name: Install powerai-license software package
-  yum:
-    name: powerai-license
-    state: latest
-  become: yes
-
-- name: Silently accept POWER AI license agreement
+- name: Silently accept PowerAI license agreement
   shell: "env IBM_POWERAI_LICENSE_ACCEPT=yes /opt/DL/license/bin/accept-powerai-license.sh"
   become: yes

--- a/software/paie52_ansible/powerai_license_install.yml
+++ b/software/paie52_ansible/powerai_license_install.yml
@@ -1,0 +1,6 @@
+---
+- name: Install powerai-license software package
+  yum:
+    name: powerai-license
+    state: latest
+  become: yes

--- a/software/paie52_install_procedure.yml
+++ b/software/paie52_install_procedure.yml
@@ -23,7 +23,10 @@
 - description: Install Anaconda installer
   tasks: install_anaconda.yml
 
-- description: Run License Script
+- description: Install PowerAI License Script
+  tasks: powerai_license_install.yml
+
+- description: Run PowerAI License Script
   tasks: powerai_license_accept.yml
 
 - description: Install Deep Learning frameworks


### PR DESCRIPTION
Users are required to interactively accept the PowerAI license agreement
on at least one server per cluster. A single server is selected
(no significance as to _which_ server) to run the manual acceptance
script. If the user accepts the license agreement on that server then
the acceptance script will be run quietly on the remaining servers.