### PR TITLE
fix: Install Anaconda to '/opt/anaconda2'

### DIFF
--- a/software/paie52.py
+++ b/software/paie52.py
@@ -28,6 +28,7 @@ from shutil import copy2, Error
 import time
 import yaml
 import code
+import json
 
 import lib.logger as logger
 from repos import PowerupRepo, PowerupRepoFromDir, PowerupRepoFromRepo, \
@@ -771,6 +772,9 @@ class software(object):
                                        'paie52_install_procedure.yml'))
         for task in install_tasks:
             heading1(f"Client Node Action: {task['description']}")
+            if task['description'] == "Install Anaconda installer":
+                _interactive_anaconda_license_accept(
+                    self.sw_vars['ansible_inventory'])
             _run_ansible_tasks(task['tasks'],
                                self.sw_vars['ansible_inventory'])
         print('Done')
@@ -807,6 +811,41 @@ def _run_ansible_tasks(tasks_path, ansible_inventory, extra_args=''):
         else:
             log.info("Ansible tasks ran successfully")
             run = False
+    return rc
+
+
+def _interactive_anaconda_license_accept(ansible_inventory):
+    log = logger.getlogger()
+    cmd = (f'ansible-inventory --inventory {ansible_inventory} --list')
+    resp, err, rc = sub_proc_exec(cmd, shell=True)
+    inv = json.loads(resp)
+    hostname, hostvars = inv['_meta']['hostvars'].popitem()
+
+    base_cmd = f'ssh -t {hostvars["ansible_user"]}@{hostname} '
+    if "ansible_ssh_private_key_file" in hostvars:
+        base_cmd += f'-i {hostvars["ansible_ssh_private_key_file"]} '
+    if "ansible_ssh_common_args" in hostvars:
+        base_cmd += f'{hostvars["ansible_ssh_common_args"]} '
+
+    cmd = base_cmd + 'ls /opt/anaconda2/'
+    resp, err, rc = sub_proc_exec(cmd)
+
+    # If install directory already exists assume license has been accepted
+    if rc == 0:
+        print(f'Anaconda license already accepted on {hostname}')
+    else:
+        print(bold('Manual Anaconda license acceptance required on at least '
+                   'one client!'))
+        rlinput(f'Press Enter to run interactively on {hostname}')
+        cmd = (base_cmd + 'sudo ~/Anaconda2-5.1.0-Linux-ppc64le.sh '
+               '-p /opt/anaconda2')
+        rc = sub_proc_display(cmd)
+        if rc == 0:
+            print('\nLicense accepted. Acceptance script will be run quietly '
+                  'on remaining servers.')
+        else:
+            log.error("Anaconda license acceptance required to continue!")
+            sys.exit('Exiting')
     return rc
 
 

--- a/software/paie52_ansible/anaconda_install.yml
+++ b/software/paie52_ansible/anaconda_install.yml
@@ -17,22 +17,6 @@
     args: -u
   when: anaconda2_dir.stat.isdir is defined and anaconda2_dir.stat.isdir
 
-- name: Get route to client
-  command: "{{ hostvars['localhost']['python_executable_local'] }} \
-  {{ hostvars['localhost']['scripts_path_local'] }}/python/ip_route_get_to.py \
-  {{ inventory_hostname }}"
-  delegate_to: localhost
-  register: host_ip
-
-- name: Download Anaconda
-  get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
-    mode: 0744
-    checksum: md5:e894dcc547a1c7d67deb04f6bba7223a
-    url: "http://{{ host_ip.stdout }}/anaconda/Anaconda2-5.1.0-Linux-ppc64le.sh"
-    dest: "{{ ansible_env.HOME }}"
-
 - name: Install Anaconda
   shell: "{{ ansible_env.HOME }}/Anaconda2-5.1.0-Linux-ppc64le.sh \
           -b -p {{ install_dir }} {{ args }}"

--- a/software/paie52_ansible/anaconda_prep.yml
+++ b/software/paie52_ansible/anaconda_prep.yml
@@ -1,0 +1,16 @@
+---
+- name: Get route to client
+  command: "{{ hostvars['localhost']['python_executable_local'] }} \
+  {{ hostvars['localhost']['scripts_path_local'] }}/python/ip_route_get_to.py \
+  {{ inventory_hostname }}"
+  delegate_to: localhost
+  register: host_ip
+
+- name: Download Anaconda
+  get_url:
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: 0744
+    checksum: md5:e894dcc547a1c7d67deb04f6bba7223a
+    url: "http://{{ host_ip.stdout }}/anaconda/Anaconda2-5.1.0-Linux-ppc64le.sh"
+    dest: "{{ ansible_env.HOME }}"

--- a/software/paie52_ansible/install_anaconda.yml
+++ b/software/paie52_ansible/install_anaconda.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set installation directory variable
   set_fact:
-    install_dir: "{{ ansible_env.HOME }}/anaconda2"
+    install_dir: "/opt/anaconda2"
 
 - name: Check if anaconda2 directory already exists
   stat:

--- a/software/paie52_ansible/install_anaconda.yml
+++ b/software/paie52_ansible/install_anaconda.yml
@@ -38,6 +38,7 @@
           -b -p {{ install_dir }} {{ args }}"
   args:
     executable: /bin/bash
+  become: yes
 
 - name: Add Anaconda2 install location to PATH in bashrc
   lineinfile:

--- a/software/paie52_install_procedure.yml
+++ b/software/paie52_install_procedure.yml
@@ -20,8 +20,11 @@
 - description: Install NCCL Library
   tasks: install_nccl.yml
 
+- description: Download Anaconda installer
+  tasks: anaconda_prep.yml
+
 - description: Install Anaconda installer
-  tasks: install_anaconda.yml
+  tasks: anaconda_install.yml
 
 - description: Run License Script
   tasks: powerai_license_accept.yml


### PR DESCRIPTION
The IBM Knowledge Center instructions specify to install Anaconda into
the '/opt/anaconda2' directory.