### PR TITLE
fix: Use generated 'software-vars.yml' path

### DIFF
--- a/software/init_clients.yml
+++ b/software/init_clients.yml
@@ -6,8 +6,6 @@
 
 - name: Init clients to access the POWER-Up server
   hosts: all
-  vars_files:
-    - /home/user/power-up/software/software-vars.yml
   tasks:
     - name: Get route to client
       command: "{{ hostvars['localhost']['python_executable_local'] }} \

--- a/software/paie52.py
+++ b/software/paie52.py
@@ -748,14 +748,40 @@ class software(object):
                            f'rc: {rc} err: {err}')
 
     def init_clients(self):
+        log = logger.getlogger()
         self.sw_vars['ansible_inventory'] = get_ansible_inventory()
         cmd = ('{} -i {} '
-               '{}/init_clients.yml --ask-become-pass'
+               '{}init_clients.yml --ask-become-pass '
+               '--extra-vars "@{}"'
                .format(get_ansible_playbook_path(),
                        self.sw_vars['ansible_inventory'],
-                       GEN_SOFTWARE_PATH))
-        resp, err, rc = sub_proc_exec(cmd)
-        print('All done')
+                       GEN_SOFTWARE_PATH,
+                       GEN_SOFTWARE_PATH + "software-vars.yml"))
+        run = True
+        while run:
+            log.info(f"Running Ansible playbook 'init_clients.yml' ...")
+            print('\nClient password required for privilege escalation')
+            resp, err, rc = sub_proc_exec(cmd, shell=True)
+            log.debug(f"cmd: {cmd}\nresp: {resp}\nerr: {err}\nrc: {rc}")
+            print("") # line break
+            if rc != 0:
+                log.warning("Ansible playbook failed!")
+                if resp != '':
+                    print(f"stdout:\n{resp}\n")
+                if err != '':
+                    print(f"stderr:\n{err}\n")
+                choice, item = get_selection(['Retry', 'Continue', 'Exit'])
+                if choice == "1":
+                    pass
+                elif choice == "2":
+                    run = False
+                elif choice == "3":
+                    log.debug('User chooses to exit.')
+                    sys.exit('Exiting')
+            else:
+                log.info("Ansible playbook ran successfully")
+                run = False
+            print('All done')
 
     def install(self):
         if self.sw_vars['ansible_inventory'] is None:


### PR DESCRIPTION
The 'paie52.py' 'init_clients' method passes the 'software-vars.yml'
path via Ansible's '--extra-vars' argument.

Logic is added to verify the 'init_clients.yml' playbook runs
successfully, and allows for user selected retry/continue/exit on
failure.