### PR TITLE
fix: Add '.condarc' with installer channel

### DIFF
--- a/software/paie52.py
+++ b/software/paie52.py
@@ -642,7 +642,7 @@ class software(object):
             dest_dir = dest_dir[4 + dest_dir.find('/srv'):5 + dest_dir.find('free')]
             # form .condarc channel entry. Note that conda adds
             # the corresponding 'noarch' channel automatically.
-            channel = f'  - http://{{ host_ip.stdout }}/{dest_dir}'
+            channel = f'  - http://{{{{ host_ip.stdout }}}}{dest_dir}'
             if channel not in self.sw_vars['ana_powerup_repo_channels']:
                 self.sw_vars['ana_powerup_repo_channels'].append(channel)
             noarch_url = os.path.split(url.rstrip('/'))[0] + '/noarch/'
@@ -686,7 +686,7 @@ class software(object):
             dest_dir = dest_dir[4 + dest_dir.find('/srv'):5 + dest_dir.find('main')]
             # form .condarc channel entry. Note that conda adds
             # the corresponding 'noarch' channel automatically.
-            channel = f'  - http://{{ host_ip.stdout }}/{dest_dir}'
+            channel = f'  - http://{{{{ host_ip.stdout }}}}{dest_dir}'
             if channel not in self.sw_vars['ana_powerup_repo_channels']:
                 self.sw_vars['ana_powerup_repo_channels'].append(channel)
             noarch_url = os.path.split(url.rstrip('/'))[0] + '/noarch/'

--- a/software/paie52_ansible/anaconda_install.yml
+++ b/software/paie52_ansible/anaconda_install.yml
@@ -7,6 +7,13 @@
   set_fact:
     install_dir: "/opt/anaconda2"
 
+- name: Get route to client
+  command: "{{ hostvars['localhost']['python_executable_local'] }} \
+  {{ hostvars['localhost']['scripts_path_local'] }}/python/ip_route_get_to.py \
+  {{ inventory_hostname }}"
+  delegate_to: localhost
+  register: host_ip
+
 - name: Check if anaconda2 directory already exists
   stat:
     path: "{{ install_dir }}"
@@ -33,3 +40,25 @@
     path: "{{ ansible_env.HOME }}/.bashrc"
     regexp: ".*PATH={{ install_dir }}/bin.*"
     line: "export PATH={{ install_dir }}/bin:$PATH"
+
+- name: Create ~/.condarc
+  file:
+    path: "{{ ansible_env.HOME }}/.condarc"
+    state: touch
+
+- name: Check if 'channels:' exists in ~/.condarc
+  shell: "grep '^channels:' {{ ansible_env.HOME }}/.condarc"
+  register: channels_exists
+  failed_when: channels_exists.rc == 2
+
+- name: Create 'channels:' key in ~/.condarc
+  lineinfile:
+    path: "{{ ansible_env.HOME }}/.condarc"
+    line: 'channels:'
+  when: channels_exists.rc == 1
+
+- name: Populate 'channels:' value in ~/.condarc
+  lineinfile:
+    path: "{{ ansible_env.HOME }}/.condarc"
+    insertafter: '^channels:.*'
+    line: "  - http://{{ host_ip.stdout }}/repos/anaconda/pkgs/free/linux-ppc64le/"

--- a/software/paie52_ansible/anaconda_install.yml
+++ b/software/paie52_ansible/anaconda_install.yml
@@ -14,25 +14,17 @@
   delegate_to: localhost
   register: host_ip
 
-- name: Check if anaconda2 directory already exists
+- name: Check if anaconda2 bin directory already exists
   stat:
-    path: "{{ install_dir }}"
+    path: "{{ install_dir }}/bin"
   register: anaconda2_dir
-
-- name: Set install args variable
-  set_fact:
-    args: ""
-
-- name: If install directory exists use update arg
-  set_fact:
-    args: -u
-  when: anaconda2_dir.stat.isdir is defined and anaconda2_dir.stat.isdir
 
 - name: Install Anaconda
   shell: "{{ ansible_env.HOME }}/{{ file }} \
-          -b -p {{ install_dir }} {{ args }}"
+          -b -p {{ install_dir }} -f"
   args:
     executable: /bin/bash
+  when: anaconda2_dir.stat.isdir is not defined or not anaconda2_dir.stat.isdir
   become: yes
 
 - name: Add Anaconda2 install location to PATH in ~/.bashrc

--- a/software/paie52_ansible/anaconda_install.yml
+++ b/software/paie52_ansible/anaconda_install.yml
@@ -38,14 +38,14 @@
 - name: Add Anaconda2 install location to PATH in ~/.bashrc
   lineinfile:
     path: "{{ ansible_env.HOME }}/.bashrc"
-    regexp: ".*PATH={{ install_dir }}/bin.*"
-    line: "export PATH={{ install_dir }}/bin:$PATH"
+    regexp: ".*PATH=.*{{ install_dir }}/bin.*"
+    line: "export PATH=\"{{ install_dir }}/bin:$PATH\""
 
 - name: Add Anaconda2 install location to PATH in /root/.bashrc
   lineinfile:
     path: "/root/.bashrc"
-    regexp: ".*PATH={{ install_dir }}/bin.*"
-    line: "export PATH={{ install_dir }}/bin:$PATH"
+    regexp: ".*PATH=.*{{ install_dir }}/bin.*"
+    line: "export PATH=\"{{ install_dir }}/bin:$PATH\""
   become: yes
 
 - name: "Create {{ install_dir }}/.condarc"

--- a/software/paie52_ansible/anaconda_install.yml
+++ b/software/paie52_ansible/anaconda_install.yml
@@ -35,30 +35,41 @@
     executable: /bin/bash
   become: yes
 
-- name: Add Anaconda2 install location to PATH in bashrc
+- name: Add Anaconda2 install location to PATH in ~/.bashrc
   lineinfile:
     path: "{{ ansible_env.HOME }}/.bashrc"
     regexp: ".*PATH={{ install_dir }}/bin.*"
     line: "export PATH={{ install_dir }}/bin:$PATH"
 
-- name: Create ~/.condarc
-  file:
-    path: "{{ ansible_env.HOME }}/.condarc"
-    state: touch
+- name: Add Anaconda2 install location to PATH in /root/.bashrc
+  lineinfile:
+    path: "/root/.bashrc"
+    regexp: ".*PATH={{ install_dir }}/bin.*"
+    line: "export PATH={{ install_dir }}/bin:$PATH"
+  become: yes
 
-- name: Check if 'channels:' exists in ~/.condarc
-  shell: "grep '^channels:' {{ ansible_env.HOME }}/.condarc"
+- name: "Create {{ install_dir }}/.condarc"
+  file:
+    path: "{{ install_dir }}/.condarc"
+    state: touch
+  become: yes
+
+- name: "Check if 'channels:' exists in {{ install_dir }}/.condarc"
+  shell: "grep '^channels:' {{ install_dir }}/.condarc"
   register: channels_exists
   failed_when: channels_exists.rc == 2
 
-- name: Create 'channels:' key in ~/.condarc
+- name: "Create 'channels:' key in {{ install_dir }}/.condarc"
   lineinfile:
-    path: "{{ ansible_env.HOME }}/.condarc"
+    path: "{{ install_dir }}/.condarc"
     line: 'channels:'
   when: channels_exists.rc == 1
+  become: yes
 
-- name: Populate 'channels:' value in ~/.condarc
+- name: "Populate 'channels:' value in {{ install_dir }}/.condarc"
   lineinfile:
-    path: "{{ ansible_env.HOME }}/.condarc"
+    path: "{{ install_dir }}/.condarc"
     insertafter: '^channels:.*'
-    line: "  - http://{{ host_ip.stdout }}/repos/anaconda/pkgs/free/linux-ppc64le/"
+    line: "{{ item }}"
+  loop: "{{ ana_powerup_repo_channels }}"
+  become: yes


### PR DESCRIPTION
If a '~/.condarc' file does not exist create it. Append an entry
pointing to installer 'repos/anaconda/pkgs/free/linux-ppc64le/' in
'channels' list.