### PR TITLE
feat: Allow client sudo password to be cached

### DIFF
--- a/scripts/python/lib/genesis.py
+++ b/scripts/python/lib/genesis.py
@@ -60,6 +60,7 @@ INV_FILE = GEN_PATH + INV_FILE_NAME
 LXC_DIR = os.path.expanduser('~/.local/share/lxc/')
 ANSIBLE = 'ansible'
 ANSIBLE_PLAYBOOK = 'ansible-playbook'
+ANSIBLE_VAULT = 'ansible-vault'
 POWER_TIME_OUT = 60
 POWER_WAIT = 5
 POWER_SLEEP_TIME = 2 * 60
@@ -212,6 +213,10 @@ def get_ansible_path():
 
 def get_ansible_playbook_path():
     return os.path.join(get_venv_path(), 'bin', ANSIBLE_PLAYBOOK)
+
+
+def get_ansible_vault_path():
+    return os.path.join(get_venv_path(), 'bin', ANSIBLE_VAULT)
 
 
 def get_os_images_path():

--- a/scripts/venv_install.sh
+++ b/scripts/venv_install.sh
@@ -33,5 +33,6 @@ pip install \
     'tabulate==0.8.2' \
     'gitpython==2.1.9' \
     'netaddr==0.7.19' \
-    'click==6.7'
+    'click==6.7' \
+    'ansible-vault==1.1.1'
 deactivate

--- a/software/paie52.py
+++ b/software/paie52.py
@@ -950,11 +950,10 @@ def _run_ansible_tasks(tasks_path, ansible_inventory, vault_pass_file,
                        extra_args=''):
     log = logger.getlogger()
     tasks_path = 'paie52_ansible/' + tasks_path
-    if 'become:' in open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read():
-        if os.path.isfile(vault_pass_file):
-            extra_args += ' --vault-password-file ' + vault_pass_file
-        else:
-            extra_args += ' --ask-become-pass'
+    if os.path.isfile(vault_pass_file):
+        extra_args += ' --vault-password-file ' + vault_pass_file
+    elif 'become:' in open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read():
+        extra_args += ' --ask-become-pass'
     cmd = ('{0} -i {1} {2}paie52_ansible/run.yml '
            '--extra-vars "task_file={2}{3}" '
            '--extra-vars "@{2}{4}" {5}'

--- a/software/paie52_ansible/sudo_test.yml
+++ b/software/paie52_ansible/sudo_test.yml
@@ -1,0 +1,6 @@
+---
+- name: Verify sudo privilege
+  command: pwd
+  args:
+    warn: no
+  become: yes


### PR DESCRIPTION
The client sudo password (must be the same for all client nodes) can
optionally be encrypted and stored in 'software-vars.yml'. Ansible Vault
is used to encrypt the password.