### PR TITLE
fix: Do not 'pip uninstall protobuf'

### DIFF
--- a/software/paie52_ansible/configure_spectrum_conductor.yml
+++ b/software/paie52_ansible/configure_spectrum_conductor.yml
@@ -32,7 +32,6 @@
        networkx==1.11 nose==1.3.7 pandas==0.20.3 pillow==4.1.1 \
        python-dateutil==2.6.1 pyyaml==3.12 requests==2.13.0 scipy==1.1.0 \
        six==1.11.0 scikit-image==0.13.0 redis-py==2.10.5 chardet==3.0.4"
-    - "pip uninstall protobuf -y"
     - "pip install --index-url http://{{ host_ip.stdout }}/repos/pypi/simple \
        numpy>=1.8.2 protobuf>=3.5.0.post1 --trusted-host {{ host_ip.stdout }}"
     - "pip install --index-url http://{{ host_ip.stdout }}/repos/pypi/simple \


### PR DESCRIPTION
Uninstalling the 'protobuf' pip package is not necessary before
installing DLI dependencies.