### PR TITLE
fix: Always unlock vault before running plays

### DIFF
--- a/software/paie11.py
+++ b/software/paie11.py
@@ -1117,7 +1117,7 @@ class software(object):
                 print(f"stderr:\n{err}\n")
             return False
 
-    def _unlock_vault(self):
+    def _unlock_vault(self, validate=True):
         while True:
             if self.sw_vars['ansible_become_pass'] is None:
                 return False
@@ -1127,7 +1127,7 @@ class software(object):
                 vault_pass_file_out.write(self.vault_pass)
             os.chmod(self.vault_pass_file, 0o600)
 
-            if self._validate_ansible_become_pass(None):
+            if not validate or self._validate_ansible_become_pass(None):
                 return True
             else:
                 print(bold("Cached sudo password decryption/validation fail!"))
@@ -1152,6 +1152,8 @@ class software(object):
                 print(bold("Validation FAILED!"))
                 self.sw_vars['ansible_inventory'] = get_ansible_inventory()
 
+        self._unlock_vault()
+
         install_tasks = yaml.load(open(GEN_SOFTWARE_PATH +
                                        'paie52_install_procedure.yml'))
         for task in install_tasks:
@@ -1159,57 +1161,58 @@ class software(object):
             if task['description'] == "Install Anaconda installer":
                 _interactive_anaconda_license_accept(
                     self.sw_vars['ansible_inventory'])
-            _run_ansible_tasks(task['tasks'],
-                               self.sw_vars['ansible_inventory'],
-                               self.vault_pass_file)
+            self._run_ansible_tasks(task['tasks'])
         print('Done')
 
+    def _run_ansible_tasks(self, tasks_path, extra_args=''):
+        log = logger.getlogger()
+        tasks_path = 'paie52_ansible/' + tasks_path
+        if self.sw_vars['ansible_become_pass'] is not None:
+            extra_args += ' --vault-password-file ' + self.vault_pass_file
+        elif 'become:' in open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read():
+            extra_args += ' --ask-become-pass'
+        cmd = ('{0} -i {1} {2}paie52_ansible/run.yml '
+               '--extra-vars "task_file={2}{3}" '
+               '--extra-vars "@{2}{4}" {5}'
+               .format(get_ansible_playbook_path(),
+                       self.sw_vars['ansible_inventory'], GEN_SOFTWARE_PATH,
+                       tasks_path, 'software-vars.yml', extra_args))
+        run = True
+        while run:
+            log.info(f'Running Ansible tasks found in \'{tasks_path}\' ...')
+            if ('notify: Reboot' in
+                    open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read()):
+                print(bold('\nThis step requires changed systems to reboot! '
+                           '(16 minute timeout)'))
+            if '--ask-become-pass' in cmd:
+                print('\nClient password required for privilege escalation')
+            elif '--vault-password-file' in cmd:
+                self._unlock_vault(validate=False)
+            resp, err, rc = sub_proc_exec(cmd, shell=True)
+            log.debug(f"cmd: {cmd}\nresp: {resp}\nerr: {err}\nrc: {rc}")
+            print("")  # line break
 
-def _run_ansible_tasks(tasks_path, ansible_inventory, vault_pass_file,
-                       extra_args=''):
-    log = logger.getlogger()
-    tasks_path = 'paie52_ansible/' + tasks_path
-    if self.sw_vars['ansible_become_pass'] is not None:
-        extra_args += ' --vault-password-file ' + vault_pass_file
-    elif 'become:' in open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read():
-        extra_args += ' --ask-become-pass'
-    cmd = ('{0} -i {1} {2}paie52_ansible/run.yml '
-           '--extra-vars "task_file={2}{3}" '
-           '--extra-vars "@{2}{4}" {5}'
-           .format(get_ansible_playbook_path(), ansible_inventory,
-                   GEN_SOFTWARE_PATH, tasks_path, 'software-vars.yml',
-                   extra_args))
-    run = True
-    while run:
-        log.info(f'Running Ansible tasks found in \'{tasks_path}\' ...')
-        if 'notify: Reboot' in open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read():
-            print(bold('\nThis step requires changed systems to reboot! '
-                       '(16 minute timeout)'))
-        if '--ask-become-pass' in cmd:
-            print('\nClient password required for privilege escalation')
-        elif '--vault-password-file' in cmd:
-            self._unlock_vault()
-        resp, err, rc = sub_proc_exec(cmd, shell=True)
-        log.debug(f"cmd: {cmd}\nresp: {resp}\nerr: {err}\nrc: {rc}")
-        print("")  # line break
-        if rc != 0:
-            log.warning("Ansible tasks failed!")
-            if resp != '':
-                print(f"stdout:\n{resp}\n")
-            if err != '':
-                print(f"stderr:\n{err}\n")
-            choice, item = get_selection(['Retry', 'Continue', 'Exit'])
-            if choice == "1":
-                pass
-            elif choice == "2":
+            # If .vault file is missing a retry should work
+            if rc != 0 and '.vault was not found' in err:
+                log.warning("Vault file missing, retrying...")
+            elif rc != 0:
+                log.warning("Ansible tasks failed!")
+                if resp != '':
+                    print(f"stdout:\n{resp}\n")
+                if err != '':
+                    print(f"stderr:\n{err}\n")
+                choice, item = get_selection(['Retry', 'Continue', 'Exit'])
+                if choice == "1":
+                    pass
+                elif choice == "2":
+                    run = False
+                elif choice == "3":
+                    log.debug('User chooses to exit.')
+                    sys.exit('Exiting')
+            else:
+                log.info("Ansible tasks ran successfully")
                 run = False
-            elif choice == "3":
-                log.debug('User chooses to exit.')
-                sys.exit('Exiting')
-        else:
-            log.info("Ansible tasks ran successfully")
-            run = False
-    return rc
+        return rc
 
 
 def _interactive_anaconda_license_accept(ansible_inventory):

--- a/software/paie11.py
+++ b/software/paie11.py
@@ -1152,8 +1152,6 @@ class software(object):
                 print(bold("Validation FAILED!"))
                 self.sw_vars['ansible_inventory'] = get_ansible_inventory()
 
-        self._unlock_vault()
-
         install_tasks = yaml.load(open(GEN_SOFTWARE_PATH +
                                        'paie52_install_procedure.yml'))
         for task in install_tasks:
@@ -1171,7 +1169,7 @@ def _run_ansible_tasks(tasks_path, ansible_inventory, vault_pass_file,
                        extra_args=''):
     log = logger.getlogger()
     tasks_path = 'paie52_ansible/' + tasks_path
-    if os.path.isfile(vault_pass_file):
+    if self.sw_vars['ansible_become_pass'] is not None:
         extra_args += ' --vault-password-file ' + vault_pass_file
     elif 'become:' in open(f'{GEN_SOFTWARE_PATH}{tasks_path}').read():
         extra_args += ' --ask-become-pass'
@@ -1189,6 +1187,8 @@ def _run_ansible_tasks(tasks_path, ansible_inventory, vault_pass_file,
                        '(16 minute timeout)'))
         if '--ask-become-pass' in cmd:
             print('\nClient password required for privilege escalation')
+        elif '--vault-password-file' in cmd:
+            self._unlock_vault()
         resp, err, rc = sub_proc_exec(cmd, shell=True)
         log.debug(f"cmd: {cmd}\nresp: {resp}\nerr: {err}\nrc: {rc}")
         print("")  # line break


### PR DESCRIPTION
Any 'pup' process instantiating a 'software' object will delete the
'.vault' file upon termination. If more than one 'pup' process is run
concurrently each process needs to verify the existence of the '.vault'
file before attempting to use it. The vault password is stored as an
attribute and thus can be used to re-unlock without re-prompting the
user.

There is still a small chance that the '.vault' file is removed
in-between checking for it's existence and starting up the
'ansible-playbook' sub-process. In this case a retry will be required.