### PR TITLE
fix: Do not use private SSH keys from '/root' dir

### DIFF
--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -361,7 +361,8 @@ def configure_ssh_keys(software_hosts_file_path):
 
     ssh_key_options = get_existing_ssh_key_pairs(no_root_keys=True)
 
-    if os.path.join(Path.home(), ".ssh",
+    user_name, user_home_dir = get_user_and_home()
+    if os.path.join(user_home_dir, ".ssh",
                     default_ssh_key_name) not in ssh_key_options:
         ssh_key_options.insert(0, 'Create New "powerup" Key Pair')
 
@@ -376,7 +377,7 @@ def configure_ssh_keys(software_hosts_file_path):
     else:
         ssh_key = item
 
-    copy_ssh_key_pair_to_user_dir(ssh_key)
+    ssh_key = copy_ssh_key_pair_to_user_dir(ssh_key)
 
     add_software_hosts_global_var(
         software_hosts_file_path,
@@ -485,12 +486,10 @@ def get_existing_ssh_key_pairs(no_root_keys=False):
     user_name, user_home_dir = get_user_and_home()
     if user_home_dir != str(Path.home()):
         user_ssh_dir = os.path.join(user_home_dir, ".ssh")
-        if (not ('/root' == str(Path.home()) and no_root_keys) and
-                os.path.isdir(user_ssh_dir)):
-            for item in listdir(user_ssh_dir):
-                item = os.path.join(user_ssh_dir, item)
-                if os.path.isfile(item + '.pub'):
-                    ssh_key_pairs.append(item)
+        for item in listdir(user_ssh_dir):
+            item = os.path.join(user_ssh_dir, item)
+            if os.path.isfile(item + '.pub'):
+                ssh_key_pairs.append(item)
 
     return ssh_key_pairs
 
@@ -542,6 +541,9 @@ def copy_ssh_key_pair_to_user_dir(private_key_path):
 
     Args:
         private_key_path (str) : Filename of private key file
+
+    Returns:
+        str: Path to user copy of private key
     """
     log = logger.getlogger()
     public_key_path = private_key_path + '.pub'
@@ -586,6 +588,11 @@ def copy_ssh_key_pair_to_user_dir(private_key_path):
 
             os.chown(user_public_key_path, user_uid, user_gid)
             os.chmod(user_public_key_path, 0o644)
+
+    else:
+        user_private_key_path = private_key_path
+
+    return user_private_key_path
 
 
 def copy_ssh_key_pair_to_hosts(private_key_path, software_hosts_file_path,

--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -359,7 +359,7 @@ def configure_ssh_keys(software_hosts_file_path):
     log = logger.getlogger()
     default_ssh_key_name = "powerup"
 
-    ssh_key_options = get_existing_ssh_key_pairs()
+    ssh_key_options = get_existing_ssh_key_pairs(no_root_keys=True)
 
     if os.path.join(Path.home(), ".ssh",
                     default_ssh_key_name) not in ssh_key_options:
@@ -460,10 +460,14 @@ def add_software_hosts_global_var(software_hosts_file_path, entry):
     _set_software_hosts_owner_mode(software_hosts_file_path)
 
 
-def get_existing_ssh_key_pairs():
+def get_existing_ssh_key_pairs(no_root_keys=False):
     """Get a list of existing SSH private/public key paths from
-    '~/.ssh/'. If called with 'sudo' then get list from both
-    '/root/.ssh/' and '~/.ssh'.
+    '~/.ssh/'. If called with 'sudo' and 'no_root_keys=False', then get
+    list from both '/root/.ssh/' and '~/.ssh'. If 'no_root_keys=True'
+    then any private keys located in '/root/.ssh' will be omitted.
+
+    Args:
+        no_root_keys (bool): Do not return any keys from '/root/.ssh'
 
     Returns:
         list of str: List of private ssh key paths
@@ -471,7 +475,8 @@ def get_existing_ssh_key_pairs():
     ssh_key_pairs = []
 
     ssh_dir = os.path.join(Path.home(), ".ssh")
-    if os.path.isdir(ssh_dir):
+    if (not ('/root' == str(Path.home()) and no_root_keys) and
+            os.path.isdir(ssh_dir)):
         for item in listdir(ssh_dir):
             item = os.path.join(ssh_dir, item)
             if os.path.isfile(item + '.pub'):
@@ -480,7 +485,8 @@ def get_existing_ssh_key_pairs():
     user_name, user_home_dir = get_user_and_home()
     if user_home_dir != str(Path.home()):
         user_ssh_dir = os.path.join(user_home_dir, ".ssh")
-        if os.path.isdir(user_ssh_dir):
+        if (not ('/root' == str(Path.home()) and no_root_keys) and
+                os.path.isdir(user_ssh_dir)):
             for item in listdir(user_ssh_dir):
                 item = os.path.join(user_ssh_dir, item)
                 if os.path.isfile(item + '.pub'):


### PR DESCRIPTION
Ansible should be usable outside of the pup program without root access.
Any SSH keys used int he Ansible inventory need to be accessible by the
user.