### PR TITLE
chore: Remove vlan from RHEL packages

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,7 +38,7 @@ if [[ $ID == "ubuntu" ]]; then
 elif [[ $ID == "rhel" ]]; then
     sudo yum -y install python2-pip python-devel python36-devel libffi-devel \
         lxc lxc-devel lxc-extra lxc-templates libvirt ipmitool\
-        debootstrap gcc vim vlan bridge-utils cpp flex bison unzip cmake \
+        debootstrap gcc vim bridge-utils cpp flex bison unzip cmake \
         fping gcc-c++ patch perl-ExtUtils-MakeMaker perl-Thread-Queue \
         ncurses-devel bash-completion yum-utils createrepo sshpass openssl-devel
     sudo systemctl start lxc.service


### PR DESCRIPTION
Remove vlan from the list of packages installed by POWER-Up's install
script. Vlan package is not needed (does not exist). Vlan support
(8021q) is enabled in RHEL 7+ by default.