### PR TITLE
fix: Add delay after switch communication

### DIFF
--- a/scripts/python/inv_add_ports.py
+++ b/scripts/python/inv_add_ports.py
@@ -47,6 +47,10 @@ class InventoryAddPorts(object):
         self.port_type = port_type
         self.inv = Inventory(cfg_file=config_path)
         self.log.debug('Add ports, port type: {}'.format(self.port_type))
+        self.sw_dict = {}
+        for sw_ai in self.cfg.yield_sw_mgmt_access_info():
+            label = sw_ai[0]
+            self.sw_dict[label] = SwitchFactory.factory(*sw_ai[1:])
 
     def get_ports(self):
         dhcp_leases = GetDhcpLeases(self.dhcp_leases_file)
@@ -72,12 +76,10 @@ class InventoryAddPorts(object):
                 mgmt_sw_cfg_mac_lists[switch_label] = \
                     SwitchCommon.get_port_to_mac(mac_info, self.log)
         else:
-            for sw_ai in self.cfg.yield_sw_mgmt_access_info():
-                self.log.debug('switch ai: {}'.format(sw_ai))
-                sw = SwitchFactory.factory(*sw_ai[1:])
-                label = sw_ai[0]
-                mgmt_sw_cfg_mac_lists[label] = \
-                    sw.show_mac_address_table(format='std')
+            for switch in self.sw_dict:
+                self.log.debug('Switch: {}'.format(switch))
+                mgmt_sw_cfg_mac_lists[switch] = \
+                    self.sw_dict[switch].show_mac_address_table(format='std')
 
         self.log.debug('Management switches MAC address tables: {}'.format(
             mgmt_sw_cfg_mac_lists))

--- a/scripts/python/lib/switch_common.py
+++ b/scripts/python/lib/switch_common.py
@@ -26,6 +26,8 @@ from orderedattrdict import AttrDict
 from enum import Enum
 from filelock import Timeout, FileLock
 from socket import gethostbyname
+from time import sleep
+from random import random
 
 import lib.logger as logger
 from lib.ssh import SSH
@@ -111,7 +113,8 @@ class SwitchCommon(object):
                               format(self.host))
             cnt += 1
             try:
-                lock.acquire(timeout=5)  # 5 sec
+                lock.acquire(timeout=5, poll_intervall=0.05)  # 5 sec, 50 ms
+                sleep(0.01)  # give switch a chance to close out comms
             except Timeout:
                 pass
         if lock.is_locked:
@@ -127,6 +130,9 @@ class SwitchCommon(object):
                 ssh_log=True,
                 look_for_keys=False)
             lock.release()
+            # sleep 60 ms to give other processes a chance.
+            sleep(0.06 + random() / 100)  # lock acquire polls at 50 ms
+            print('lock is locked?: {}'.format(lock.is_locked))
             return data
         else:
             self.log.error('Unable to acquire lock for switch {}'.format(self.host))

--- a/scripts/python/lib/switch_common.py
+++ b/scripts/python/lib/switch_common.py
@@ -132,7 +132,8 @@ class SwitchCommon(object):
             lock.release()
             # sleep 60 ms to give other processes a chance.
             sleep(0.06 + random() / 100)  # lock acquire polls at 50 ms
-            print('lock is locked?: {}'.format(lock.is_locked))
+            if lock.is_locked:
+                self.log.error('Lock is locked. Should be unlocked')
             return data
         else:
             self.log.error('Unable to acquire lock for switch {}'.format(self.host))


### PR DESCRIPTION
Add a randomized sleep delay after surrendering a switch lock to give
other processes a chance to access the switch.