### PR TITLE
fix: Add host key in get dependent package script

### DIFF
--- a/software/get-dependent-packages.sh
+++ b/software/get-dependent-packages.sh
@@ -28,6 +28,13 @@ echo
 export SSHPASS=$PASSWORD
 
 user=$(whoami)
+
+if ! ssh-keygen -F $2 >/dev/null; then
+    known_hosts="$HOME/.ssh/known_hosts"
+    echo "Adding host key for '$2' to '$known_hosts'"
+    ssh-keyscan $2 >> $known_hosts
+fi
+
 sshpass -e ssh -t $1@$2 'sudo yum -y install yum-utils'
 
 sshpass -e scp /home/$user/power-up/software/dependent-packages-paie11.list \

--- a/software/get-dependent-packages.sh
+++ b/software/get-dependent-packages.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 set -e
-cd ~
+cd "$(dirname "$0")"
 if [[ -z $1 || -z $2 ]]; then
     echo 'usage: get-dependent-packages userid host'
     exit
@@ -37,12 +37,12 @@ fi
 
 sshpass -e ssh -t $1@$2 'sudo yum -y install yum-utils'
 
-sshpass -e scp /home/$user/power-up/software/dependent-packages-paie11.list \
+sshpass -e scp ./dependent-packages-paie11.list \
     $1@$2:/home/$1/dependent-packages-paie11.list
 
 sshpass -e ssh -t $1@$2 'mkdir -p tempdl && sudo yumdownloader --archlist=ppc64le \
     --resolve --destdir tempdl $(tr "\n" " " < dependent-packages-paie11.list)'
 
-sshpass -e scp -r $1@$2:/home/customer/tempdl/ ~
+sshpass -e scp -r $1@$2:~/tempdl/ ~
 
 sshpass -e ssh $1@$2 'rm -rf tempdl/ && rm dependent-packages-paie11.list'


### PR DESCRIPTION
When using 'sshpass' to make 'ssh' calls, if host key is not present in
a user's 'known_hosts' file the script will fail without any output to
stdout or stderr (rc=6). If this situation is encountered within
'get-dependent-packages.sh', the user is left without any information on
why the script failed in a situation that is easily remedied. Logic is
now preset to check if the host key exists, if it does not then it is
added automatically (a message is printed to stdout to notify the user).