### PR TITLE
fix: Handle environment variables

### DIFF
--- a/software/paie111.py
+++ b/software/paie111.py
@@ -1227,7 +1227,7 @@ class software(object):
                     self.sw_vars['ansible_inventory'],
                     self.sw_vars['content_files']['anaconda'])
             elif (task['description'] ==
-                    "Install IBM Spectrum Conductor with Spark"):
+                    "Install IBM Spectrum Conductor"):
                 _set_spectrum_conductor_install_env(
                     self.sw_vars['ansible_inventory'], 'spark')
             elif (task['description'] ==

--- a/software/paie111_ansible/install_spectrum_conductor_dli.yml
+++ b/software/paie111_ansible/install_spectrum_conductor_dli.yml
@@ -42,7 +42,7 @@
       egocomputehost: EGOCOMPUTEHOST=Y
   when: inventory_hostname not in groups['master']
 
-- name: Install IBM Spectrum Conductor with Spark
+- name: Install IBM Spectrum Conductor DLI
   shell: "{{ egocomputehost }} {{ ansible_env.HOME }}/{{ file }} --quiet"
   environment: "{{ envs }}"
   args:


### PR DESCRIPTION
Correctly handle task name change in playbook
install_spectrum_conductor_with_spark.yml. Task name "Install
Spectrum conductor with spark" changed to "Install Spectrum
conductor". This caused the install function in paie111.py to
not create the environment variables file.