### PR TITLE
fix: Install PowerAI Enterprise license

### DIFF
--- a/software/paie111_ansible/powerai_license_accept.yml
+++ b/software/paie111_ansible/powerai_license_accept.yml
@@ -1,10 +1,36 @@
 ---
-- name: Install powerai-license software package
+- name: Get enterprise license filename from software-vars.yml
+  set_fact:
+    file: "{{ content_files['powerai-enterprise-license'].split('/')[-1] }}"
+
+- name: Get route to client
+  command: "{{ hostvars['localhost']['python_executable_local'] }} \
+  {{ hostvars['localhost']['scripts_path_local'] }}/python/ip_route_get_to.py \
+  {{ inventory_hostname }}"
+  delegate_to: localhost
+  register: host_ip
+
+- name: Download license rpm
+  get_url:
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+    mode: 0744
+    url: "http://{{ host_ip.stdout }}/powerai-enterprise-license/{{ file }}"
+    dest: "{{ ansible_env.HOME }}"
+
+- name: Install powerai-enterprise-license
   yum:
-    name: powerai-license
-    state: latest
+    name: "{{ ansible_env.HOME }}/{{ file }}"
+    state: present
   become: yes
 
-- name: Silently accept POWER AI license agreement
-  shell: "env IBM_POWERAI_LICENSE_ACCEPT=yes /opt/DL/license/bin/accept-powerai-license.sh"
+- name: Configure license script to run silently
+  replace:
+    path: /opt/DL/powerai-enterprise/license/bin/accept-powerai-enterprise-license.sh
+    regexp: '\$1'
+    replace: 'yes'
+  become: yes
+
+- name: Accept POWER AI Enterprise license agreement
+  shell: /opt/DL/powerai-enterprise/license/bin/accept-powerai-enterprise-license.sh
   become: yes


### PR DESCRIPTION
The PowerAI Enterprise license is required to scale DDL beyond four
nodes.

The 'accept-powerai-enterprise-license.sh' script does not allow running
silently. There is a 'SILENT_MODE' variable in the script which is
assigned to '$1', which seems to indicate an intention to allow running
silently by passing an argument. The script also has logic to exit and
display usage if _any_ argument is passed, which prevents use of the
'SILENT_MODE'. To enable silent install the script must be modified to
set 'SILENT_MODE=yes'.