### PR TITLE
fix: Limit memory udev rule change to POWER9 nodes

### DIFF
--- a/software/paie111_ansible/disable_udev_mem_auto_onlining.yml
+++ b/software/paie111_ansible/disable_udev_mem_auto_onlining.yml
@@ -6,6 +6,7 @@
     src: /lib/udev/rules.d/40-redhat.rules
     dest: /etc/udev/rules.d/
   become: yes
+  loop: "{{ ansible_processor | unique | select('match', 'POWER9') | list }}"
 
 - name: Disable udev Memory Auto-Onlining Rule
   replace:
@@ -13,6 +14,7 @@
     regexp: '^(SUBSYSTEM=="memory")'
     replace: '#\1'
   become: yes
+  loop: "{{ ansible_processor | unique | select('match', 'POWER9') | list }}"
   notify: Reboot
 
 - meta: flush_handlers


### PR DESCRIPTION
The udev Memory Auto-Onlining Rule is only required for POWER9 servers.