### PR TITLE
fix: Check 'root' known_hosts for client host keys

### DIFF
--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -329,9 +329,8 @@ def _check_known_hosts(host_list):
     log = logger.getlogger()
     known_hosts_files = [os.path.join(Path.home(), ".ssh", "known_hosts")]
     user_name, user_home_dir = get_user_and_home()
-    if user_home_dir != str(Path.home()):
-        known_hosts_files.append(os.path.join(user_home_dir,
-                                              ".ssh", "known_hosts"))
+    if os.environ['USER'] == 'root' and user_name != 'root':
+        known_hosts_files.append('/root/.ssh/known_hosts')
 
     for host in host_list:
         for known_hosts in known_hosts_files:


### PR DESCRIPTION
I mistakenly thought that pathlib 'Path.home()' would return the 'root'
user's home directory when 'software_hosts.py' was called using sudo.
This caused the logic to verify client hosts keys were in 'known_hosts'
files to only check the user file.

Now the logic specifically adds the root 'known_hosts' file
('/root/.ssh/known_hosts') to be checked in the case of sudo calling the
script.