### PR TITLE
refactor: Change prompt to create new inventory

### DIFF
--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -821,14 +821,8 @@ def get_ansible_inventory():
                       .format(software_hosts_file_path))
             # If no software inventory file exists create one using template
             else:
-                print("Software inventory file not found.")
-                if click.confirm('Do you want to create a new inventory from '
-                                 'a template?'):
-                    _create_new_software_inventory(software_hosts_file_path)
-                elif click.confirm('Do you want to exit the program?'):
-                    sys.exit(1)
-                else:
-                    continue
+                rlinput("Press enter to create client node inventory")
+                _create_new_software_inventory(software_hosts_file_path)
 
             # Print software inventory file contents
             if os.path.isfile(software_hosts_file_path):


### PR DESCRIPTION
If a client node inventory file is not found (e.g. initial run on
'--init-clients') transition right into creating an inventory without
any "file not found" messages. This makes it more clear to a user that
they are _not_ on an error path.