### PR TITLE
fix: Install PowerAI SnapML packages

### DIFF
--- a/software/paie111_ansible/install_frameworks.yml
+++ b/software/paie111_ansible/install_frameworks.yml
@@ -10,4 +10,5 @@
     # - tensorboard
     - power-mldl
     - power-ddl
+    - power-snapml
   become: yes


### PR DESCRIPTION
PowerAI Enterprise 1.1.1 includes PowerAI SnapML framework packages.