### PR TITLE
feat: Enable multiple management hosts

### DIFF
--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -865,7 +865,7 @@ def validate_software_inventory(software_hosts_file_path):
         _validate_host_list_network(hosts_list)
 
         # Validate  master node count is exactly 1
-        _validate_master_node_count(software_hosts_file_path, 1, 1)
+        _validate_master_node_count(software_hosts_file_path, 1, 5)
 
         # Ensure hosts keys exist in known_hosts
         _check_known_hosts(hosts_list)

--- a/software/paie111.py
+++ b/software/paie111.py
@@ -1513,6 +1513,8 @@ def _set_spectrum_conductor_install_env(ansible_inventory, package):
                       f'CLUSTERADMIN: {hostvars["ansible_user"]}\n')
         replace_regex(envs_path, '^DLI_CONDA_HOME:\s*$',
                       f'DLI_CONDA_HOME: /opt/anaconda2\n')
+        replace_regex(envs_path, '^DLI_FRAMEWORK_HOME:\s*$',
+                      f'DLI_FRAMEWORK_HOME: /opt/DL\n')
 
     env_validated = False
     while not env_validated:

--- a/software/paie111_ansible/add_hosts_to_cluster.yml
+++ b/software/paie111_ansible/add_hosts_to_cluster.yml
@@ -20,9 +20,17 @@
     file: envs_spectrum_conductor_dli.yml
     name: envs
 
-- name: If adding management host run egoconfig mghost
+- name: Run egoconfig mghost on first management host
   shell: "source /opt/ibm/spectrumcomputing/profile.platform && \
-  egoconfig mghost $DLI_SHARED_FS"
+  egoconfig mghost $DLI_SHARED_FS -f"
+  environment: "{{ envs }}"
+  args:
+    executable: /bin/bash
+  when: ansible_host == groups['master'][0]
+
+- name: Run egoconfig mghost on additional management hosts
+  shell: "source /opt/ibm/spectrumcomputing/profile.platform && \
+  egoconfig mghost $DLI_SHARED_FS -f"
   environment: "{{ envs }}"
   args:
     executable: /bin/bash

--- a/software/paie111_ansible/entitle_spectrum_conductor_dli.yml
+++ b/software/paie111_ansible/entitle_spectrum_conductor_dli.yml
@@ -55,3 +55,16 @@
     out.stdout is not search("EGO\s*:\s*Entitled") or
     out.stdout is not search("Conductor\s*:\s*Entitled") or
     out.stdout is not search("Conductor Deep Learning Impact\s*:\s*Entitled")
+
+- name: Include configuration environment variables
+  include_vars:
+    file: envs_spectrum_conductor_dli.yml
+    name: envs
+
+- name: Once services are started, set recursive permissions for DLI_SHARED_FS
+  shell: "{{ item }}"
+  loop:
+    - setfacl -R -d -m u:$CLUSTERADMIN:rwx $DLI_SHARED_FS
+    - setfacl -R -d -m o::--- $DLI_SHARED_FS
+  environment: "{{ envs }}"
+  become: yes

--- a/software/paie111_ansible/envs_spectrum_conductor_dli_template.yml
+++ b/software/paie111_ansible/envs_spectrum_conductor_dli_template.yml
@@ -4,6 +4,7 @@
 CLUSTERADMIN:
 DLI_SHARED_FS:
 DLI_CONDA_HOME:
+DLI_FRAMEWORK_HOME:
 ## DLI defaults to 5000 and 5001 for DLI_INSIGHTS_MONITOR_PORT
 ## and DLI_INSIGHTS_OPTIMIZER_PORT but these ports are registered
 ## in /etc/services in RHEL 7.5 and cause installation of DLI to


### PR DESCRIPTION
Allow multiple management hosts to be defined within the 'master'
inventory group.

At least one and at most five nodes must be defined within the 'master'
group for inventory validation to pass. More than five nodes requires
additional configuration (see bottom of
https://www.ibm.com/support/knowledgecenter/SSFHA8_1.1.1/enterprise/install/host_add.html).

Configuring the order of failover hosts is _not_ included here - users
are required to logon to the cluster management web console:
https://www.ibm.com/support/knowledgecenter/SSFHA8_1.1.1/enterprise/install/config_master_host_failover.html