### PR TITLE
fix: Add botocore to pkg-lists111.yml

### DIFF
--- a/software/pkg-lists111.yml
+++ b/software/pkg-lists111.yml
@@ -103,7 +103,7 @@ python_pkgs:
 - asn1crypto==0.24.0
 - Babel==2.6.0
 - boto>=2.32
-- '"urllib3>=1.20,<1.24"'
+- '"botocore>=1.12.19,<1.13.0"'
 - boto3
 - bz2file
 - certifi==2018.4.16
@@ -202,7 +202,7 @@ python_pkgs:
 - subprocess32==3.5.2
 - Theano==1.0.2
 - unicodecsv==0.14.1
-- urllib3==1.23
+- '"urllib3>=1.20,<1.24"'
 - warlock==1.3.0
 - wcwidth==0.1.7
 - Werkzeug==0.14.1


### PR DESCRIPTION
Add botocore back to pkg-lists111.yml and move the redundant
urllib3 entry which appears to have been pasted on top of where
botocore should be.