### PR TITLE
fix: Complete system setup steps before install

### DIFF
--- a/software/paie111_ansible/complete_system_setup.yml
+++ b/software/paie111_ansible/complete_system_setup.yml
@@ -1,10 +1,16 @@
 ---
+- name: Clear limit.conf EOF marker
+  lineinfile:
+      path: /etc/security/limits.conf
+      line: '# End of file'
+      state: absent
+  become: yes
+
 - name: Configure the required max processors and open files limits
   lineinfile:
       path: /etc/security/limits.conf
       line: "{{ item }}"
-      insertbefore: '^# End of file'
-  with_items:
+  loop:
       - "root   soft    nproc     65536"
       - "root   hard    nproc     65536"
       - "root   soft    nofile    65536"
@@ -15,6 +21,13 @@
       - "{{ ansible_user }}   hard    nofile    65536"
   become: yes
 
+- name: Apend limit.conf EOF marker
+  lineinfile:
+      path: /etc/security/limits.conf
+      line: '# End of file'
+      state: present
+  become: yes
+
 - name: Set the vm_max_map_count kernel value dynamically
   command: sysctl -w vm.max_map_count=262144
   become: yes
@@ -23,26 +36,4 @@
   lineinfile:
       path: /etc/sysctl.conf
       line: vm.max_map_count=262144
-  become: yes
-
-- name: Enable Performance Governor
-  command: cpupower -c all frequency-set -g performance
-  become: yes
-
-- name: Enable GPU persistence mode
-  command: "{{ item }}"
-  with_items:
-    - systemctl enable nvidia-persistenced
-    - systemctl start nvidia-persistenced
-  become: yes
-
-- name: Set GPU memory and graphics clocks to their maximums
-  command: "{{ item }}"
-  with_items:
-    - nvidia-smi -ac 715,1480
-    - nvidia-smi -ac 877,1530
-  become: yes
-
-- name: Set SMT-2
-  command: ppc64_cpu --smt=2
   become: yes

--- a/software/paie111_ansible/powerai_tuning.yml
+++ b/software/paie111_ansible/powerai_tuning.yml
@@ -1,0 +1,22 @@
+---
+- name: Enable Performance Governor
+  command: cpupower -c all frequency-set -g performance
+  become: yes
+
+- name: Enable GPU persistence mode
+  command: "{{ item }}"
+  with_items:
+    - systemctl enable nvidia-persistenced
+    - systemctl start nvidia-persistenced
+  become: yes
+
+- name: Set GPU memory and graphics clocks to their maximums
+  command: "{{ item }}"
+  with_items:
+    - nvidia-smi -ac 715,1480
+    - nvidia-smi -ac 877,1530
+  become: yes
+
+- name: Set SMT-2
+  command: ppc64_cpu --smt=2
+  become: yes

--- a/software/paie111_install_procedure.yml
+++ b/software/paie111_install_procedure.yml
@@ -26,6 +26,9 @@
 - description: Install Anaconda installer
   tasks: anaconda_install.yml
 
+- description: Complete System Setup
+  tasks: complete_system_setup.yml
+
 - description: Install PowerAI Enterprise License Script
   tasks: powerai_license_install.yml
 
@@ -55,5 +58,5 @@
 - description: Add all hosts to cluster
   tasks: add_hosts_to_cluster.yml
 
-- description: Post-Install Configurations
-  tasks: post_install_config.yml
+- description: PowerAI tuning recommendations
+  tasks: powerai_tuning.yml


### PR DESCRIPTION
Configuring limits for the maximum number of processors (nprocs) and the
maximum number of files open (nofile) on hosts must be done _before_
starting up services (else not all services will start successfully).
This step is described towards the end of PAIE 1.1.1 KC instructions for
"Set up your system (Manual install)"
(https://www.ibm.com/support/knowledgecenter/en/SSFHA8_1.1.1/powerai_setup.html)
and is thus moved from 'post_install_config.yml' into
'complete_system_setup.yml'.

The remaining tasks in 'post_install_config.yml' are related to PowerAI
tuning recommendations and have thus been moved into the task list
'powerai_tuning.yml'.