### PR TITLE
fix: Update paramiko due to security vulnerability

### DIFF
--- a/scripts/venv_install.sh
+++ b/scripts/venv_install.sh
@@ -29,7 +29,7 @@ pip install \
     'pyasn1==0.4.2' \
     'pysnmp==4.4.4' \
     'pyaml==17.12.1' \
-    'paramiko==2.4.1' \
+    'paramiko==2.4.2' \
     'tabulate==0.8.2' \
     'gitpython==2.1.9' \
     'filelock==3.0.4'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ pylint>=1.7.2
 mock>=1.2
 netaddr~=0.7.18
 testrepository>=0.0.20  # Apache-2.0/BSD
-ansible~=2.4.3.0
+ansible~=2.5.5
 orderedattrdict==1.5
 pyroute2==0.5.0
 jsonschema==2.6.0
@@ -16,6 +16,6 @@ wget==3.2
 pyasn1==0.4.2
 pysnmp==4.4.4
 pyaml==17.12.1
-paramiko==2.4.1
+paramiko==2.4.2
 tabulate==0.8.2
 gitpython==2.1.9


### PR DESCRIPTION
Paramiko 2.4.1 is exposed to a security vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2018-1000805

Also, 'test-requirements.txt' contained pointers to old versions of
python modules (as installed by 'scripts/venv_install.sh'.