### PR TITLE
fix: Install 'ipaddress' python module for Cobbler

### DIFF
--- a/scripts/python/lib/container.py
+++ b/scripts/python/lib/container.py
@@ -324,6 +324,9 @@ class Container(object):
                 cmd.append(pkg)
             self.run_command(cmd, stdout=self.fd)
 
+        # Install additional python modules
+        self.run_command(['pip', 'install', 'ipaddress'], stdout=self.fd)
+
         # Create project directory
         self.run_command(['mkdir', '-p', self.cont_package_path],
                          stdout=self.fd)


### PR DESCRIPTION
The Cobbler web GUI fails to load because of an 'ImportError' for the
module 'ipaddress'. Cobbler uses the system level python installation so
this package needs to be installed outside of the pup python venv. The
standard Ubuntu 14.04 repos do not have a 'python-ipaddress' package
(releases >14.04 do) so the module is installed running 'pip' as root
user.