### PR TITLE
fix: Use python3 when downloading Pypi packages

### DIFF
--- a/scripts/python/repos.py
+++ b/scripts/python/repos.py
@@ -571,8 +571,8 @@ class PowerupPypiRepoFromRepo(PowerupRepo):
             for pkg in pkg_list2:
                 print(pkg)
                 cmd = (f'python -m pip download --platform ppc64le --no-deps '
-                       f'--index-url={alt_url} -d {self.pypirepo_dir} {pkg} '
-                       f'--trusted-host {host}')
+                       f'--python-version 27 --index-url={alt_url} '
+                       f'-d {self.pypirepo_dir} {pkg} --trusted-host {host}')
                 resp, err, rc = sub_proc_exec(cmd, shell=True)
                 if rc != 0:
                     self.log.error('Error occured while downloading python package: '
@@ -581,8 +581,8 @@ class PowerupPypiRepoFromRepo(PowerupRepo):
         else:
             for pkg in pkg_list2:
                 print(pkg)
-                cmd = (f'python -m pip download --platform ppc64le  --no-deps '
-                       f'-d {self.pypirepo_dir} {pkg}')
+                cmd = (f'python -m pip download --platform ppc64le --no-deps '
+                       f'--python-version 27 -d {self.pypirepo_dir} {pkg}')
                 resp, err, rc = sub_proc_exec(cmd, shell=True)
                 if rc != 0:
                     self.log.error('Error occured while downloading python packages: '

--- a/scripts/python/repos.py
+++ b/scripts/python/repos.py
@@ -570,7 +570,7 @@ class PowerupPypiRepoFromRepo(PowerupRepo):
             host = re.search(r'http://([^/]+)', alt_url).group(1)
             for pkg in pkg_list2:
                 print(pkg)
-                cmd = (f'python2.7 -m pip download --platform ppc64le --no-deps '
+                cmd = (f'python -m pip download --platform ppc64le --no-deps '
                        f'--index-url={alt_url} -d {self.pypirepo_dir} {pkg} '
                        f'--trusted-host {host}')
                 resp, err, rc = sub_proc_exec(cmd, shell=True)
@@ -581,7 +581,7 @@ class PowerupPypiRepoFromRepo(PowerupRepo):
         else:
             for pkg in pkg_list2:
                 print(pkg)
-                cmd = (f'python2.7 -m pip download --platform ppc64le  --no-deps '
+                cmd = (f'python -m pip download --platform ppc64le  --no-deps '
                        f'-d {self.pypirepo_dir} {pkg}')
                 resp, err, rc = sub_proc_exec(cmd, shell=True)
                 if rc != 0:


### PR DESCRIPTION
Power-Up creates a local Pypi repository using 'pip download'. The
'--platform' option is not supported in older version of 'pip'. Calling
'pip' using 'python2.7 -m pip' does not ensure 'pip' installed in the
system python2.7 is new enough to support '--platform'. The pup python3
venv installs the latest available version of 'pip' and thus can be used
to download Pypi packages using the '--platform' option.