### PR TITLE
fix: Use relative remote path when using 'scp'

### DIFF
--- a/software/get-dependent-packages.sh
+++ b/software/get-dependent-packages.sh
@@ -38,7 +38,7 @@ fi
 sshpass -e ssh -t $1@$2 'sudo yum -y install yum-utils'
 
 sshpass -e scp ./dependent-packages-paie111.list \
-    $1@$2:/home/$1/dependent-packages-paie111.list
+    $1@$2:dependent-packages-paie111.list
 
 sshpass -e ssh -t $1@$2 'mkdir -p tempdl && sudo yumdownloader --archlist=ppc64le \
     --resolve --destdir tempdl $(tr "\n" " " < dependent-packages-paie111.list)'


### PR DESCRIPTION
When using 'scp' to copy 'dependent-packages-paie111.list' to the remote
host there's no need to specify an absolute path to the destination.
Later in the 'get-dependent-packages.sh' when the package list is given
to 'yumdownloader' a relative path is used.