### PR TITLE
fix: Update get-dependent-packages.sh

### DIFF
--- a/software/get-dependent-packages.sh
+++ b/software/get-dependent-packages.sh
@@ -22,12 +22,14 @@ if [[ -z $1 || -z $2 ]]; then
     exit
 fi
 
-#echo 'Enter password for '$1
+pkglist=$(python -c \
+"import yaml;\
+pkgs = yaml.load(open('pkg-lists111.yml'));\
+print(' '.join(pkgs['yum_pkgs']))")
+
 read -sp 'Enter password for '$1': ' PASSWORD
 echo
 export SSHPASS=$PASSWORD
-
-user=$(whoami)
 
 if ! ssh-keygen -F $2 >/dev/null; then
     known_hosts="$HOME/.ssh/known_hosts"
@@ -36,13 +38,19 @@ if ! ssh-keygen -F $2 >/dev/null; then
 fi
 
 sshpass -e ssh -t $1@$2 'sudo yum -y install yum-utils'
+echo
+# Packages are saved to a different directory on this machine
+# so that the packages are still present if you execute this
+# script against the machine it's running on.
+# Remove ~/tempdl to remove stray content and cause scp to copy
+# files to it directly without creating puptempdl dir under it.
+rm -rf ~/tempdl
 
-sshpass -e scp ./dependent-packages-paie111.list \
-    $1@$2:dependent-packages-paie111.list
+sshpass -e ssh -t $1@$2 'mkdir -p ~/puptempdl && sudo yumdownloader --archlist=ppc64le \
+    --resolve --destdir ~/puptempdl '$pkglist
 
-sshpass -e ssh -t $1@$2 'mkdir -p tempdl && sudo yumdownloader --archlist=ppc64le \
-    --resolve --destdir tempdl $(tr "\n" " " < dependent-packages-paie111.list)'
+echo Retrieving packages
+sshpass -e scp -r $1@$2:~/puptempdl/ ~/tempdl
 
-sshpass -e scp -r $1@$2:~/tempdl/ ~
-
-sshpass -e ssh $1@$2 'rm -rf tempdl/ && rm dependent-packages-paie111.list'
+echo Remove remote directory
+sshpass -e ssh $1@$2 'rm -rf ~/puptempdl'

--- a/software/paie111.py
+++ b/software/paie111.py
@@ -794,11 +794,6 @@ class software(object):
         heading1(f'Set up {repo_name} repository')
         # list to str
         dep_list = ' '.join(self.pkgs['yum_pkgs'])
-        # Generate simple text list for use by get-dependent-packages.sh
-        # utility script.
-        with open(os.path.join(GEN_SOFTWARE_PATH,
-                  'dependent-packages-paie111.list'), 'w') as f:
-            f.write(dep_list)
 
         file_more = GEN_SOFTWARE_PATH + 'dependent-packages.list'
         if os.path.isfile(file_more):


### PR DESCRIPTION
Read dependent packages list directly from pkg-lists111.yml. This
avoids the need for the intermediate dependent-packages-paie111.list
file and allows execution of get-dependent-packages.sh without having
previously run pup software --prep.

Use a different directory name on the remote (proxy) node. This
allows you to run get-dependent-packages.sh against the same node
it's executing on and still have the packages present when execution
completes. It also allows test execution without requiring a
separate proxy node.