### PR TITLE
fix: Stop on error during python venv install

### DIFF
--- a/scripts/venv_install.sh
+++ b/scripts/venv_install.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 sudo -E -H pip install --upgrade virtualenv
 virtualenv --no-wheel --system-site-packages ${1}pup-venv
 source ${1}pup-venv/bin/activate


### PR DESCRIPTION
The python venv installation script, 'scripts/venv_install.sh' is
invoked in 'scripts/install.sh' with it's own shell, and thus need to
'set -e' to stop execution on errors.