### PR TITLE
fix: Disable netplan in Ubuntu 18.04 clients

### DIFF
--- a/os-images/config/snippets/get_ubuntu_packages
+++ b/os-images/config/snippets/get_ubuntu_packages
@@ -1,0 +1,21 @@
+## Copyright 2018 IBM Corp.
+##
+## All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+#set output = "d-i pkgsel/include string openssh-server vlan bridge-utils vim python ifenslave ntp ntpdate"
+#if $os_version == 'bionic'
+    #set output = "d-i pkgsel/include string openssh-server vlan bridge-utils vim python ifenslave ifupdown"
+#end if
+#echo $output

--- a/os-images/config/ubuntu-default.seed
+++ b/os-images/config/ubuntu-default.seed
@@ -45,7 +45,7 @@ $SNIPPET('password')
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false
 tasksel tasksel/first multiselect standard
-d-i pkgsel/include string openssh-server vlan bridge-utils vim python ifenslave
+$SNIPPET('get_ubuntu_packages')
 d-i pkgsel/update-policy select none
 d-i grub-installer/only_debian boolean false
 d-i grub-installer/with_other_os boolean false

--- a/playbooks/templates/interfaces_ubuntu.j2
+++ b/playbooks/templates/interfaces_ubuntu.j2
@@ -33,6 +33,10 @@ iface lo inet loopback
 auto {{ interface['iface'] }}
 iface {{ interface['iface'] }}{% if 'method' in interface %} inet {{ interface['method'] }}{% endif %}
 
+    {% if interface.gateway is defined %}
+    pre-up /sbin/route del default
+    {% endif %}
+
     {% for key, value in interface.iteritems() %}
         {% if key not in ['label', 'description', 'iface', 'method'] %}
     {{ key }} {{ value }}

--- a/scripts/python/cobbler_add_systems.py
+++ b/scripts/python/cobbler_add_systems.py
@@ -133,10 +133,20 @@ def cobbler_add_systems(cfg_file=None):
                 ks_meta,
                 token)
         kernel_options = inv.get_nodes_os_kernel_options(index)
+        if 'ubuntu-18.04' in cobbler_profile.lower():
+            if kernel_options is None:
+                kernel_options = ''
+            if 'netcfg/do_not_use_netplan=true' not in kernel_options:
+                kernel_options += ' netcfg/do_not_use_netplan=true'
         if kernel_options is not None:
             cobbler_server.modify_system(
                 new_system_create,
                 "kernel_options",
+                kernel_options,
+                token)
+            cobbler_server.modify_system(
+                new_system_create,
+                "kernel_options_post",
                 kernel_options,
                 token)
         comment = ""


### PR DESCRIPTION
Post-deploy network configuration for Ubuntu clients requires
'ifupdown'. Ubuntu 18.04 has 'netplan' enabled by default, but can be
disable through a kernel argument. The kernel argument to disable
netplan along with the 'ifupdown' software package will be automatically
configured if the config file 'node_templates: os: profile:' value
contains 'ubuntu-18.04'.

Also, commit 83d7f75 removed 'ntp' and 'ntpdate' packages from the
default Ubuntu preseed file. These should still be installed in Ubuntu
14.04 & 16.04, so the 'pkgsel/include' directive is now moved into a
snippet with logic to set the packages to install based on release
version.