### PR TITLE
fix: Configure DNS nameservers in Ubuntu 18.04

### DIFF
--- a/os-images/config/snippets/set_ubuntu_resolv_conf
+++ b/os-images/config/snippets/set_ubuntu_resolv_conf
@@ -1,0 +1,20 @@
+## Copyright 2018 IBM Corp.
+##
+## All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+#if $os_version == 'bionic'
+    #echo "in-target rm /etc/resolv.conf;"
+    #echo "in-target ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf;"
+#end if

--- a/os-images/config/snippets/set_ubuntu_resolv_conf
+++ b/os-images/config/snippets/set_ubuntu_resolv_conf
@@ -15,6 +15,6 @@
 ## limitations under the License.
 ##
 #if $os_version == 'bionic'
-    #echo "in-target rm /etc/resolv.conf;"
-    #echo "in-target ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf;"
+    #echo "in-target rm /etc/resolv.conf; \\\n"
+    #echo "in-target ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf; \\"
 #end if

--- a/os-images/config/ubuntu-default.seed
+++ b/os-images/config/ubuntu-default.seed
@@ -55,5 +55,6 @@ in-target mkdir /root/.ssh; \
 in-target /bin/chmod 700 /root/.ssh; \
 in-target /usr/bin/wget http://$http_server/authorized_keys -O /root/.ssh/authorized_keys; \
 in-target /bin/chmod 600 /root/.ssh/authorized_keys; \
+$SNIPPET('set_ubuntu_resolv_conf')
 $SNIPPET('kickstart_done')
 d-i finish-install/reboot_in_progress note

--- a/playbooks/tasks/create_interfaces.yml
+++ b/playbooks/tasks/create_interfaces.yml
@@ -54,6 +54,17 @@
   when: ansible_distribution == 'Ubuntu'
   notify: Reboot
 
+- name: Add nameservers to resolved.conf.j2 (Ubuntu 18.04+)
+  template:
+    src: "{{ playbook_dir }}/templates/resolved.conf.j2"
+    dest: "/etc/systemd/resolved.conf"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+    backup: yes
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic'
+  notify: Reboot
+
 - name: Generate RHEL/CentOS interfaces files
   template:
     src: "{{ playbook_dir }}/templates/interfaces_rhel.j2"

--- a/playbooks/templates/resolved.conf.j2
+++ b/playbooks/templates/resolved.conf.j2
@@ -1,0 +1,39 @@
+{# Copyright 2018 IBM Corp.
+
+   All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+#}
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See resolved.conf(5) for details
+
+[Resolve]
+DNS={% for interface in interfaces %}{% if 'dns_nameservers' in interface %}{{ interface['dns_nameservers'] }} {% endif %}{% endfor %}
+
+#FallbackDNS=
+#Domains=
+#LLMNR=no
+#MulticastDNS=no
+#DNSSEC=no
+#Cache=yes
+#DNSStubListener=yes


### PR DESCRIPTION
Ubuntu 18.04 uses systemd-resolved which requires DNS nameservers to be
set in '/etc/systemd/resolved.conf' (instead of in the '/etc/network/'
interfaces files). Also, '/run/systemd/resolve/resolv.conf' is symlinked
from '/etc/resolv.conf' for compatibility with traditional Linux
programs (see systemd-resolved manpage).