### PR TITLE
fix: Use 'dhclient' to build post-deploy mac table

### DIFF
--- a/playbooks/activate_client_interfaces.yml
+++ b/playbooks/activate_client_interfaces.yml
@@ -51,7 +51,7 @@
     - name: Create temporary dhclient.conf
       lineinfile:
         path: /run/dhclient.conf
-        line: 'timeout 1'
+        line: 'timeout 5'
         create: True
 
     - name: Update switch mac address tables

--- a/playbooks/activate_client_interfaces.yml
+++ b/playbooks/activate_client_interfaces.yml
@@ -25,13 +25,12 @@
     - name: Bring down all interfaces except ansible communication interface
       command: "ip link set dev {{ item }} down"
       when:
-        - "{{ item != 'lo' }}"
-        - "{{ ansible_host != \
-           hostvars[inventory_hostname]['ansible_' + \
-           item.replace('-', '_')].get('ipv4', {}).get('address') }}"
-        - "{{ hostvars[inventory_hostname]['ansible_' + \
-           item.replace('-', '_')]['active'] }}"
-      with_items: "{{ ansible_interfaces }}"
+        - item != 'lo'
+        - "ansible_host != hostvars[inventory_hostname]['ansible_' + \
+           item.replace('-', '_')].get('ipv4', {}).get('address')"
+        - "hostvars[inventory_hostname]['ansible_' + \
+           item.replace('-', '_')]['active']"
+      loop: "{{ ansible_interfaces }}"
 
     - name: Pause for networks to go down
       pause:
@@ -40,43 +39,35 @@
     - name: Insure all interfaces are up
       command: "ip link set dev {{ item }} up"
       when:
-        - "{{ item != 'lo' }}"
-        - "{{ ansible_host != hostvars[inventory_hostname]['ansible_' + \
-           item.replace('-', '_')].get('ipv4', {}).get('address') }}"
-      with_items: "{{ ansible_interfaces }}"
-      ignore_errors: yes
+        - item != 'lo'
+        - "ansible_host != hostvars[inventory_hostname]['ansible_' + \
+           item.replace('-', '_')].get('ipv4', {}).get('address')"
+      loop: "{{ ansible_interfaces }}"
 
     - name: Pause for networks to come up
       pause:
         seconds: 5
 
+    - name: Create temporary dhclient.conf
+      lineinfile:
+        path: /run/dhclient.conf
+        line: 'timeout 1'
+        create: True
 
-    # Update switch mac address tables by adding temporary link local
-    # ipv4 address.  This also forces an ipv6 link local setup which
-    # drives traffic to the switch.
     - name: Update switch mac address tables
-      command: "ip addr add 169.254.0.2/24 dev {{ item }}"
+      shell: "dhclient {{ item }} -1 || true"
       become: true
       when:
-        - "{{ item != 'lo' }}"
-        - "{{ ansible_host != hostvars[inventory_hostname]['ansible_' + \
-           item.replace('-', '_')].get('ipv4', {}).get('address') }}"
-      with_items: "{{ ansible_interfaces }}"
-      ignore_errors: yes
+        - item != 'lo'
+        - "ansible_host != hostvars[inventory_hostname]['ansible_' + \
+           item.replace('-', '_')].get('ipv4', {}).get('address')"
+      loop: "{{ ansible_interfaces }}"
+      environment:
+        PATH_DHCLIENT_CONF: /run/dhclient.conf
 
-    - name: Pause for ipv6 link local
+    - name: Pause for ipv4 link local
       pause:
         seconds: 5
-
-    - name: clear the temporary addresses
-      command: "ip addr del 169.254.0.2/24 dev {{ item }}"
-      become: true
-      when:
-        - "{{ item != 'lo' }}"
-        - "{{ ansible_host != hostvars[inventory_hostname]['ansible_' + \
-           item.replace('-', '_')].get('ipv4', {}).get('address') }}"
-      with_items: "{{ ansible_interfaces }}"
-      ignore_errors: yes
 
     # A one time copy is made of the network interfaces files after initial
     # OS install. This is now attempted at the end of install in wait_for_
@@ -97,7 +88,7 @@
             remote_src: yes
             force: no
             owner: root
-          with_items: "{{ files_to_copy.files }}"
+          loop: "{{ files_to_copy.files }}"
       when: (ansible_distribution == 'RedHat') or
             (ansible_distribution == 'CentOS')
 

--- a/playbooks/handlers/reboot.yml
+++ b/playbooks/handlers/reboot.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017 IBM Corp.
+# Copyright 2018 IBM Corp.
 #
 # All Rights Reserved.
 #
@@ -16,19 +16,7 @@
 # limitations under the License.
 
 - name: Reboot
-  command: shutdown -r +1 "Ansible is issuing a reboot!"
-  async: 90
-  poll: 0
-  changed_when: true
-  notify: Wait for system to come back up
-
-- name: Wait for system to come back up
-  local_action: wait_for
-  args:
-    delay: "{{ reboot_delay_time }}"
-    port: 22
-    search_regex: OpenSSH
-    timeout: "{{ reboot_wait_interval }}"
-    host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
+  reboot:
+    reboot_timeout: 1000
 
 ...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.0
+ansible==2.7.1
 ansible-vault==1.2.0
 click==7.0
 docker==3.5.1

--- a/scripts/python/inventory.py
+++ b/scripts/python/inventory.py
@@ -37,8 +37,6 @@ INVENTORY_INIT = {
     'client_nodes': {
         'children': [],
         'vars': {
-            'reboot_wait_interval': 660,
-            'reboot_delay_time': 300
         }
     },
     '_meta': {

--- a/scripts/python/lib/inventory.py
+++ b/scripts/python/lib/inventory.py
@@ -645,6 +645,41 @@ class Inventory(object):
         self._add_macs(macs, self.InvKey.DATA)
         self.dbase.dump_inventory(self.inv)
 
+    def get_data_interfaces(self):
+        """Get data interface information
+
+        Returns:
+            dict of list of 5-tuples: {node1: [(switch, port, device,
+                                                mac), ...],
+                                       node2: [(...)], ...}
+        """
+        mac_dict = {}
+        for node in self.inv.nodes:
+            device_list = []
+            for index, device in enumerate(
+                    node[self.InvKey.DATA][self.InvKey.DEVICES]):
+                switch = node[self.InvKey.DATA][self.InvKey.SWITCHES][index]
+                port = node[self.InvKey.DATA][self.InvKey.PORTS][index]
+                mac = node[self.InvKey.DATA][self.InvKey.MACS][index]
+                device_list.append((switch, port, device, mac))
+            mac_dict[node[self.InvKey.HOSTNAME]] = device_list
+
+        return mac_dict
+
+    def check_data_interfaces_macs(self):
+        """Check if MAC addresses are populated for all data interfaces
+
+        Returns:
+            bool: True if all MACs are populated
+        """
+        for node in self.inv.nodes:
+            device_list = []
+            for mac in node[self.InvKey.DATA][self.InvKey.MACS]:
+                if mac is None:
+                    return False
+
+        return True
+
     def _add_ipaddrs(self, ipaddrs, type_):
         for node in self.inv.nodes:
             for index, mac in enumerate(node[type_][self.InvKey.MACS]):

--- a/scripts/python/set_port_macs.py
+++ b/scripts/python/set_port_macs.py
@@ -18,6 +18,7 @@
 import argparse
 import os.path
 import sys
+from tabulate import tabulate
 
 import lib.logger as logger
 from lib.config import Config
@@ -47,6 +48,18 @@ def main(config_path=None):
                     sw_info[0], sw_info[1], sw_info[2], port_to_macs))
         macs.update({sw_info[0]: port_to_macs})
     inv.add_macs_data(macs)
+
+    if not inv.check_data_interfaces_macs():
+        _print_data_macs(inv)
+
+
+def _print_data_macs(inv):
+    blue = '\033[94m'
+    endc = '\033[0m'
+    header = ['Switch', 'Port', 'Device', 'MAC']
+    for node, info in inv.get_data_interfaces().items():
+        print(f'\n{blue}Client Node: {node}:{endc}')
+        print(tabulate(info, header))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Assigning static IP addresses to client node data interfaces was not
generating MAC address table entries. Using dhclient to force a single
DHCP request (with a timeout of 1 second) works reliably.