### PR TITLE
fix: Ensure IPV4 forwarding is enabled

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,7 +100,8 @@ if [[ $ipv4_forwarding == "net.ipv4.conf.all.forwarding = 0" ]]; then
         echo "Adding '$net_ipv4_conf=1' to $sysctl_docker"
         echo "$net_ipv4_conf=1" >> $sysctl_docker
     elif grep "$net_ipv4_conf=0" $sysctl_docker &>/dev/null; then
-        echo "Replacing '$net_ipv4_conf=0' with '$net_ipv4_conf=1' in $sysctl_docker"
+        echo -n "Replacing '$net_ipv4_conf=0' with '$net_ipv4_conf=1' in "
+        echo "$sysctl_docker"
         sed -i "s/$net_ipv4_conf=0/$net_ipv4_conf=1/" $sysctl_docker
     fi
 
@@ -111,6 +112,7 @@ if [[ $ipv4_forwarding == "net.ipv4.conf.all.forwarding = 0" ]]; then
         echo "ERROR: Unable to enable IPV4 forwarding!"
         echo "Ensure '/sbin/sysctl $net_ipv4_conf' is set to '1'"
     fi
+fi
 
 sudo -E -H pip install --upgrade pip==18.0
 sudo -E -H pip install --upgrade setuptools

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,7 +105,25 @@ if [[ $ipv4_forwarding == "net.ipv4.conf.all.forwarding = 0" ]]; then
         sed -i "s/$net_ipv4_conf=0/$net_ipv4_conf=1/" $sysctl_docker
     fi
 
-    sudo systemctl restart docker
+    docker_ps=$(docker ps)
+    if [[ "$docker_ps" = *$'\n'* ]]; then
+        echo
+        echo    "The following Docker containers are running:"
+        echo    "$docker_ps"
+        echo
+        echo    "Is it OK to stop all containers and restart Docker service?"
+        read -p "(y/n)? " -r
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            restart_docker=true
+        else
+            restart_docker=false
+        fi
+    else
+        restart_docker=true
+    fi
+    if [ "$restart_docker" = true ]; then
+        sudo systemctl restart docker
+    fi
 
     ipv4_forwarding=$(/sbin/sysctl $net_ipv4_conf)
     if [[ $ipv4_forwarding == "net.ipv4.conf.all.forwarding = 0" ]]; then


### PR DESCRIPTION
IPV4 forwarding needs to be enabled to allow Docker containers to access
networks through the host (e.g. internet).