### PR TITLE
fix: Remove system 'pip' commands from install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,10 +83,6 @@ if ! docker container ls &> /dev/null; then
     sudo usermod -aG docker $USER  # user needs to logout & login
 fi
 
-sudo -E -H pip install --upgrade pip==18.0
-sudo -E -H pip install --upgrade setuptools
-sudo -E -H pip install --upgrade wheel
-
 /bin/bash "${BASH_SOURCE%/*}/venv_install.sh"
 
 # Create empty log file to ensure user is owner


### PR DESCRIPTION
The 'pip' commands in 'install.sh' to upgrade 'pip', 'setuptools' and
'wheel' at a system level are no longer needed. All 'pip' actions should
take place inside the 'pup-venv' Python virtual environment. This was
causing a problem on a system whose 'pip' executable was located at
'/usr/local/bin/pip' but the root PATH (when using sudo) did not include
'/usr/local/bin' causing 'install.sh' to fail.