### PR TITLE
fix: Disable RHEL zeroconf routes

### DIFF
--- a/playbooks/activate_client_interfaces.yml
+++ b/playbooks/activate_client_interfaces.yml
@@ -22,6 +22,12 @@
     - name: Gather facts
       setup:
 
+    - name: Disable ZEROCONF Routes
+      lineinfile:
+        path: /etc/sysconfig/network
+        line: 'NOZEROCONF=yes'
+      when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
+
     - name: Bring down all interfaces except ansible communication interface
       command: "ip link set dev {{ item }} down"
       when:


### PR DESCRIPTION
RHEL defaults to enabling zero-configuration routes when a DHCP request
fails. Since switching to use 'dhclient' to activate data interfaces
(for MAC address harvesting - see 1827702) all data interfaces are left
with "extra" zerconf routes.