### PR TITLE
fix: Correct command bootstrap 'executable' syntax

### DIFF
--- a/playbooks/tasks/cmd_bootstrap.yml
+++ b/playbooks/tasks/cmd_bootstrap.yml
@@ -18,16 +18,16 @@
 - name: Run Bootstrap Command
   shell: "{{ item.command }}"
   args:
-    "{{ item.executable | default('/bin/sh') }}"
+    executable: "{{ item.executable | default('/bin/sh') }}"
   when: ((item.hosts in groups and hostname in groups[item.hosts]) or
          item.hosts == hostname)
-  with_items: "{{ software_bootstrap }}"
+  loop: "{{ software_bootstrap }}"
   register: command_result
 
 - name: Print stdout
   debug:
     var: item.stdout_lines
-  with_items: "{{ command_result.results }}"
+  loop: "{{ command_result.results }}"
   when: command_result.results is defined
 
 ...


### PR DESCRIPTION
The executable passed to the Ansible 'shell' module should be formatted
as a key value inside the 'args'. See
https://docs.ansible.com/ansible/latest/modules/shell_module.html for
details.

Also 'with_items:' is refactored to use the newer 'loop:' syntax.