### PR TITLE
fix: Disable stale PXE ifcfg-* script if renaming

### DIFF
--- a/playbooks/configure_operating_systems.yml
+++ b/playbooks/configure_operating_systems.yml
@@ -31,7 +31,6 @@
   hosts: client_nodes
   tasks:
     - include: tasks/create_interfaces.yml
-  handlers:
     - include: handlers/reboot.yml
 
 - name: Wait for networks to initialize

--- a/playbooks/tasks/create_interfaces.yml
+++ b/playbooks/tasks/create_interfaces.yml
@@ -77,17 +77,22 @@
   with_items: "{{ interfaces }}"
   notify: Reboot
 
-- name: Disable original PXE interface scripts if rename=True
+- name: Find all interface configuration scripts
+  find:
+    paths: /etc/sysconfig/network-scripts/
+    patterns: 'ifcfg-*'
+  register: ifcfg_scripts
+
+- name: Disable any interfaces not defined in inventory
   lineinfile:
-    path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
+    path: "{{ item.path }}"
     regexp: '^ONBOOT='
-    line: 'ONBOOT=no  # Disabled due to interface rename'
+    line: 'ONBOOT=no  # Disabled by POWER-Up'
   when:
     - ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
-    - pxe.rename[0]
-    - "ansible_host == hostvars[inventory_hostname]['ansible_' + \
-       item.replace('-', '_')].get('ipv4', {}).get('address')"
-    - item != pxe.devices[0]
-  loop: "{{ ansible_interfaces }}"
+    - (item.path | basename).split('-')[1] != 'lo'
+    - (item.path | basename).split('-')[1] not in pxe.devices
+    - (item.path | basename).split('-')[1] not in data.devices
+  loop: "{{ ifcfg_scripts.files }}"
 
 ...

--- a/playbooks/tasks/create_interfaces.yml
+++ b/playbooks/tasks/create_interfaces.yml
@@ -77,4 +77,17 @@
   with_items: "{{ interfaces }}"
   notify: Reboot
 
+- name: Disable original PXE interface scripts if rename=True
+  lineinfile:
+    path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
+    regexp: '^ONBOOT='
+    line: 'ONBOOT=no  # Disabled due to interface rename'
+  when:
+    - ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
+    - pxe.rename[0]
+    - "ansible_host == hostvars[inventory_hostname]['ansible_' + \
+       item.replace('-', '_')].get('ipv4', {}).get('address')"
+    - item != pxe.devices[0]
+  loop: "{{ ansible_interfaces }}"
+
 ...

--- a/playbooks/tasks/create_interfaces.yml
+++ b/playbooks/tasks/create_interfaces.yml
@@ -22,7 +22,6 @@
     owner: "root"
     group: "root"
     mode: "0644"
-  notify: Reboot
 
 # Need to add support for Red Hat
 - name: Copy udev links rules
@@ -40,7 +39,6 @@
   command: "update-initramfs -u"
   register: updateinitramfs
   when: ansible_distribution == 'Ubuntu'
-  notify: Reboot
 - debug: var=updateinitramfs.stdout_lines
 
 - name: Generate Ubuntu interfaces file
@@ -52,7 +50,6 @@
     mode: "0644"
     backup: yes
   when: ansible_distribution == 'Ubuntu'
-  notify: Reboot
 
 - name: Add nameservers to resolved.conf.j2 (Ubuntu 18.04+)
   template:
@@ -63,7 +60,6 @@
     mode: "0644"
     backup: yes
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'bionic'
-  notify: Reboot
 
 - name: Generate RHEL/CentOS interfaces files
   template:
@@ -75,7 +71,6 @@
     backup: no
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
   with_items: "{{ interfaces }}"
-  notify: Reboot
 
 - name: Find all interface configuration scripts
   find:


### PR DESCRIPTION
Since the PXE interface is using during OS installation a 'ifcfg-*'
script is automatically generated. If this interface is renamed and
reconfigured during post-deploy the original 'ifcfg-*' script is left in
place and causes systemd to report errors when starting
'network.service'. Instead of removing the 'ifcfg-*' script this patch
sets 'ONBOOT=no' so that 'network.service' does not try to activate it.

I have not tested Ubuntu to see if similar behavior exists there. This
patch only affects RHEL client nodes.