### PR TITLE
test: Address tox ansible-lint environment fails

### DIFF
--- a/software/paie111_ansible/reboot.yml
+++ b/software/paie111_ansible/reboot.yml
@@ -1,19 +1,7 @@
 ---
 - name: Reboot
-  command: shutdown -r +1 "Ansible is issuing a reboot!"
-  args:
-    warn: no
-  async: 90
-  poll: 0
-  changed_when: true
-  notify: Wait for system to come back up
+  reboot:
+    reboot_timeout: 1000
   become: yes
 
-- name: Wait for system to come back up
-  local_action: wait_for
-  args:
-    delay: 300
-    port: 22
-    search_regex: OpenSSH
-    timeout: 660
-    host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
+...

--- a/software/paie112_ansible/reboot.yml
+++ b/software/paie112_ansible/reboot.yml
@@ -1,19 +1,7 @@
 ---
 - name: Reboot
-  command: shutdown -r +1 "Ansible is issuing a reboot!"
-  args:
-    warn: no
-  async: 90
-  poll: 0
-  changed_when: true
-  notify: Wait for system to come back up
+  reboot:
+    reboot_timeout: 1000
   become: yes
 
-- name: Wait for system to come back up
-  local_action: wait_for
-  args:
-    delay: 300
-    port: 22
-    search_regex: OpenSSH
-    timeout: 660
-    host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
+...

--- a/tox.ini
+++ b/tox.ini
@@ -64,8 +64,10 @@ commands =
 basepython = python3.6
 commands =
     # Perform an Ansible lint check
-    bash -c "find {toxinidir} -name '*.yml' -o -name '*.yaml' | xargs \
-    ansible-lint -x ANSIBLE0006,ANSIBLE0012,ANSIBLE0013,ANSIBLE0014,ANSIBLE0016"
+    bash -c \"find {toxinidir} -name 'paie*_install_procedure.yml' -prune -o \
+    -name '*.tox*' -prune -o -name '*.yml' -print -o -name '*.yaml' -print | \
+    xargs ansible-lint -x \
+    ANSIBLE0006,ANSIBLE0012,ANSIBLE0013,ANSIBLE0014,ANSIBLE0016,204\"
 
 [testenv:commit-message-validate]
 basepython = python3.6


### PR DESCRIPTION
Rule "[204] Lines should be no longer than 120 chars" is added to the
exception list. There isn't a good way to split encrypted password
values in config files across multiple lines.