### PR TITLE
feat: Set static hostname and domain

### DIFF
--- a/docs/Config-Specification.rst
+++ b/docs/Config-Specification.rst
@@ -783,6 +783,7 @@ node_templates:
               password:
           os:
               hostname_prefix:
+              domain:
               profile:
               install_device:
               users:
@@ -821,20 +822,21 @@ node_templates:
 |         os:                        |         password: pass                        | | Required keys:                                                                 |          |
 |         physical_interfaces:       |     os:                                       | |   *label*   - Unique label used to reference this template.                    |          |
 |         interfaces:                |         hostname_prefix: ctrl                 | |   *ipmi*    - IPMI credentials. See `node_templates: ipmi                      |          |
-|         networks:                  |         profile: ubuntu-14.04-server-ppc64el  |                 <node_templates_ipmi_>`_.                                        |          |
-|         roles:                     |         install_device: /dev/sda              | |   *os*      - Operating system configuration. See `node_templates: os          |          |
-|                                    |         kernel_options: quiet                 |                 <node_templates_os_>`_.                                          |          |
-|                                    |     physical_interfaces:                      | |   *physical_interfaces* - Physical network interface port mappings. See        |          |
-|                                    |         ipmi:                                 |                             `node_templates: physical_interfaces                 |          |
-|                                    |             - switch: mgmt_switch_1           |                             <node_templates_physical_ints_>`_.                   |          |
-|                                    |               ports:                          |                                                                                  |          |
-|                                    |                   - 1                         | | Optional keys:                                                                 |          |
-|                                    |                   - 3                         | |   *interfaces* - Post-deploy interface assignments. See `node_templates:       |          |
-|                                    |                   - 5                         |                    interfaces <node_templates_interfaces_>`_.                    |          |
-|                                    |         pxe:                                  | |   *networks*   - Post-deploy network (interface group) assignments. See        |          |
-|                                    |             - switch: mgmt_switch_1           |                    `node_templates: networks <node_templates_networks_>`_.       |          |
-|                                    |               ports:                          | |   *roles*      - Ansible group assignment. See `node_templates: roles          |          |
-|                                    |                   - 2                         |                    <node_templates_roles_>`_.                                    |          |
+|         networks:                  |         domain: ibm.com                       |                 <node_templates_ipmi_>`_.                                        |          |
+|         roles:                     |         profile: ubuntu-14.04-server-ppc64el  | |   *os*      - Operating system configuration. See `node_templates: os          |          |
+|                                    |         install_device: /dev/sda              |                 <node_templates_os_>`_.                                          |          |
+|                                    |         kernel_options: quiet                 | |   *physical_interfaces* - Physical network interface port mappings. See        |          |
+|                                    |     physical_interfaces:                      |                             `node_templates: physical_interfaces                 |          |
+|                                    |         ipmi:                                 |                             <node_templates_physical_ints_>`_.                   |          |
+|                                    |             - switch: mgmt_switch_1           |                                                                                  |          |
+|                                    |               ports:                          | | Optional keys:                                                                 |          |
+|                                    |                   - 1                         | |   *interfaces* - Post-deploy interface assignments. See `node_templates:       |          |
+|                                    |                   - 3                         |                    interfaces <node_templates_interfaces_>`_.                    |          |
+|                                    |                   - 5                         | |   *networks*   - Post-deploy network (interface group) assignments. See        |          |
+|                                    |         pxe:                                  |                    `node_templates: networks <node_templates_networks_>`_.       |          |
+|                                    |             - switch: mgmt_switch_1           | |   *roles*      - Ansible group assignment. See `node_templates: roles          |          |
+|                                    |               ports:                          |                    <node_templates_roles_>`_.                                    |          |
+|                                    |                   - 2                         |                                                                                  |          |
 |                                    |                   - 4                         |                                                                                  |          |
 |                                    |                   - 6                         |                                                                                  |          |
 |                                    |                                               |                                                                                  |          |
@@ -860,22 +862,21 @@ node_templates:
 | ::                                 | ::                                            | Client node operating system configuration.                                      | **yes**  |
 |                                    |                                               |                                                                                  |          |
 |   node_templates:                  |   - ...                                       | | Required keys:                                                                 |          |
-|       - ...                        |     os:                                       |                                                                                  |          |
-|         os:                        |         hostname_prefix: controller           |                                                                                  |          |
-|             hostname_prefix:       |         profile: ubuntu-14.04-server-ppc64el  |                                                                                  |          |
+|       - ...                        |     os:                                       | |   *profile*         - Cobbler profile to use for OS installation. This         |          |
+|         os:                        |         hostname_prefix: controller           |                         name usually should match the name of the                |          |
+|             hostname_prefix:       |         domain: ibm.com                       |                         installation image (with or without the'.iso' extension).|          |
+|             domain:                |         profile: ubuntu-14.04-server-ppc64el  | |   *install_device*  - Path to installation disk device.                        |          |
 |             profile:               |         install_device: /dev/sda              |                                                                                  |          |
-|             install_device:        |         users:                                | |   *profile*         - Cobbler profile to use for OS installation. This         |          |
-|             users:                 |             - name: root                      |                         name usually should match the name of the                |          |
-|                 - name:            |               password: <crypted password>    |                         installation image (with or without the'.iso' extension).|          |
-|                   password:        |             - name: user1                     | |   *install_device*  - Path to installation disk device.                        |          |
-|             groups:                |               password: <crypted password>    |                                                                                  |          |
-|                 - name:            |               groups: sudo,testgroup1         | | Optional keys:                                                                 |          |
-|             kernel_options:        |         groups:                               | |   *hostname_prefix* - Prefix used to assign hostnames to client nodes          |          |
-|                                    |             - name: testgroup1                |                         belonging to this node template. A "-" and               |          |
-|                                    |             - name: testgroup2                |                         enumeration is added to the end of the prefix to         |          |
-|                                    |         kernel_options: quiet                 |                         make a unique hostname for each client node              |          |
-|                                    |                                               |                         (e.g. "controller-1" and "controoler-2").                |          |
-|                                    |                                               | |   *users*           - OS user accounts to create. All parameters in the        |          |
+|             install_device:        |         users:                                | | Optional keys:                                                                 |          |
+|             users:                 |             - name: root                      | |   *hostname_prefix* - Prefix used to assign hostnames to client nodes          |          |
+|                 - name:            |               password: <crypted password>    |                         belonging to this node template. A "-" and               |          |
+|                   password:        |             - name: user1                     |                         enumeration is added to the end of the prefix to         |          |
+|             groups:                |               password: <crypted password>    |                         make a unique hostname for each client node              |          |
+|                 - name:            |               groups: sudo,testgroup1         |                         (e.g. "controller-1" and "controoler-2").                |          |
+|             kernel_options:        |         groups:                               | |   *domain*          - Domain name used to set client FQDN.                     |          |
+|                                    |             - name: testgroup1                |                         (e.g. with 'domain: ibm.com': controller-1.ibm.com)      |          |
+|                                    |             - name: testgroup2                |                         (e.g. without 'domain' value: controller-1.localdomain)  |          |
+|                                    |         kernel_options: quiet                 | |   *users*           - OS user accounts to create. All parameters in the        |          |
 |                                    |                                               |                         `Ansible user module <ansible_user_module_>`_ are        |          |
 |                                    |                                               |                         supported. **note:** Plaintext user passwords are not    |          |
 |                                    |                                               |                         supported. For help see                                  |          |

--- a/os-images/config/RHEL-7-default.ks
+++ b/os-images/config/RHEL-7-default.ks
@@ -11,6 +11,7 @@ timezone America/Chicago --utc
 
 auth --enableshadow --enablemd5
 user $SNIPPET('defaultuser') --groups=wheel $SNIPPET('password')
+network --hostname=$getVar('hostname').$getVar('domain', 'localdomain')
 
 clearpart --all --initlabel
 ignoredisk --only-use=$getVar('install_disk', '/dev/sda')

--- a/os-images/config/ubuntu-default.seed
+++ b/os-images/config/ubuntu-default.seed
@@ -1,4 +1,4 @@
-# Copyright 2018 IBM Corp.
+# Copyright 2019 IBM Corp.
 #
 # All Rights Reserved.
 #
@@ -20,8 +20,8 @@ $SNIPPET('kickstart_start')
 d-i debian-installer/locale string en_US
 d-i console-setup/ask_detect boolean false
 d-i keyboard-configuration/layoutcode string us
-d-i netcfg/get_hostname string unassigned-hostname
-d-i netcfg/get_domain string unassigned-domain
+d-i netcfg/get_hostname string $getVar('hostname')
+d-i netcfg/get_domain string $getVar('domain', 'localdomain')
 d-i netcfg/wireless_wep string
 d-i netcfg/target_network_config select ifupdown
 d-i apt-setup/use_mirror boolean true

--- a/scripts/python/cobbler_add_systems.py
+++ b/scripts/python/cobbler_add_systems.py
@@ -108,6 +108,9 @@ def cobbler_add_systems(cfg_file=None):
                     (hostname, disks))
         if raid1_enabled:
             ks_meta += 'raid1_enabled=true '
+        domain = inv.get_nodes_os_domain(index)
+        if domain is not None:
+            ks_meta += 'domain=%s ' % domain
         users = inv.get_nodes_os_users(index)
         if users is not None:
             for user in users:

--- a/scripts/python/lib/inventory.py
+++ b/scripts/python/lib/inventory.py
@@ -79,6 +79,7 @@ class Inventory(object):
         OS = 'os'
         PROFILE = 'profile'
         INSTALL_DEVICE = 'install_device'
+        DOMAIN = 'domain'
         USERS = 'users'
         KERNEL_OPTIONS = 'kernel_options'
         ROLES = 'roles'
@@ -553,6 +554,23 @@ class Inventory(object):
                 self.inv.nodes,
                 self.InvKey.OS,
                 index)[self.InvKey.INSTALL_DEVICE]
+        except KeyError:
+            pass
+
+    def get_nodes_os_domain(self, index=None):
+        """Get nodes OS domain
+        Args:
+            index (int, optional): List index
+
+        Returns:
+            str: nodes OS domain
+        """
+
+        try:
+            return self._get_members(
+                self.inv.nodes,
+                self.InvKey.OS,
+                index)[self.InvKey.DOMAIN]
         except KeyError:
             pass
 


### PR DESCRIPTION
Set static hostname and domain using 'hostnamectl' (called at install
time through the kickstart/preseed file).

Add optional 'domain' key in config file 'node_templates: os:'
dictionary to configure domain. If a value is not specified
'localdomain' will be used.