### PR TITLE
refactor: Update Ansible config for cleaner output

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -8,3 +8,6 @@ fact_caching_timeout = 86400
 fact_caching_connection = ./.facts/
 log_path = ./ansible.log
 jinja2_extensions = jinja2.ext.do
+stdout_callback = minimal
+bin_ansible_callbacks = True
+retry_files_enabled = False

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -8,6 +8,6 @@ fact_caching_timeout = 86400
 fact_caching_connection = ./.facts/
 log_path = ./ansible.log
 jinja2_extensions = jinja2.ext.do
-stdout_callback = minimal
+stdout_callback = unixy
 bin_ansible_callbacks = True
 retry_files_enabled = False

--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -41,7 +41,7 @@ import lib.logger as logger
 from lib.genesis import get_python_path, CFG_FILE, \
     get_dynamic_inventory_path, get_playbooks_path, get_ansible_path
 from lib.utilities import bash_cmd, sub_proc_exec, heading1, get_selection, \
-    bold, get_yesno, remove_line, append_line, rlinput, ansible_pprint
+    bold, get_yesno, remove_line, append_line, rlinput
 
 
 def _get_dynamic_inventory():
@@ -369,7 +369,7 @@ def _validate_ansible_ping(software_hosts_file_path, hosts_list):
                                          software_hosts_file_path))
     resp, err, rc = sub_proc_exec(cmd)
     if str(rc) != "0":
-        msg = f'Ansible ping validation failed:\n{ansible_pprint(resp)}'
+        msg = f'Ansible ping validation failed:\n{resp}'
         log.debug(msg)
         if 'WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!' in msg:
             print(


### PR DESCRIPTION
The Ansible 'minimal' callback plugin formats json output with line
breaks and indentation. This eliminates the need for the
'ansible_pprint' function in 'scripts/python/lib/utilities.py' - calls
to this function should be removed in the next 'paie*' module release.

Retry files are not used and create clutter.