### PR TITLE
fix: Address post-deploy Ansible host warnings

### DIFF
--- a/scripts/python/inventory.py
+++ b/scripts/python/inventory.py
@@ -107,6 +107,12 @@ def generate_dynamic_inventory():
                     dynamic_inventory[_role] = {'hosts': []}
                 dynamic_inventory[_role]['hosts'].append(hostname)
 
+    if 'solution_keys' not in dynamic_inventory:
+        dynamic_inventory['solution_keys'] = {'hosts': []}
+
+    if 'solution_inventory' not in dynamic_inventory:
+        dynamic_inventory['solution_inventory'] = {'hosts': []}
+
     return dynamic_inventory
 
 


### PR DESCRIPTION
The post-deploy task to transfer SSH key pairs and the inventory file to
any client nodes assigned the 'solution_keys' and 'solution_inventory'
roles generates a prominent warning messages when the role is not
present. The dynamic inventory script would only create Ansible groups
for defined roles. This commit create empty 'solution_keys' and
'solution_inventory' Ansible groups in order to suppress the "[WARNING]:
Could not match supplied host pattern" message.