### PR TITLE
Check for existing DHCP servers#6351 

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,7 +40,7 @@ if [[ $ID == "ubuntu" ]]; then
     sudo apt-get -y install libffi-dev libssl-dev python3-dev \
         python-netaddr ipmitool aptitude vim vlan bridge-utils gcc cpp \
         python-tabulate fping g++ make unzip libncurses5 libncurses5-dev \
-        sshpass dnsmasq
+        sshpass dnsmasq nmap
 
     if ! type "docker"; then
         sudo apt-get -y install \
@@ -68,7 +68,7 @@ elif [[ $ID == "rhel" ]]; then
         vim bridge-utils cpp flex bison unzip cmake fping gcc-c++ patch \
         perl-ExtUtils-MakeMaker perl-Thread-Queue ncurses-devel \
         bash-completion yum-utils createrepo sshpass python-tabulate \
-        openssl-devel tcpdump dnsmasq
+        openssl-devel tcpdump dnsmasq nmap
     sudo python36 -m ensurepip --default-pip
 
     if ! type "docker"; then

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -322,16 +322,18 @@ class OSinstall_form(npyscreen.Form):
                                              relx=relx)
             self.fields[item].entry_widget.add_handlers({curses.KEY_F1:
                                                         self.h_help})
-
-
 if __name__ == '__main__':
 
     logger.create('nolog', 'info')
     log = logger.getlogger()
 
     profile = 'profile.yml'
-    osi = OSinstall()
-    osi.load_profile(profile)
-    osi.run()
-    p = osi.get_profile_tuple()
-    print(p)
+    try:
+        osi = OSinstall()
+        osi.load_profile(profile)
+        osi.run()
+        p = osi.get_profile_tuple()
+        log.debug(p)
+        print(p)
+    except KeyboardInterrupt:
+        log.info("Exiting ...")

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -32,6 +32,10 @@ GEN_SAMPLE_CONFIGS_PATH = get_sample_configs_path()
 
 IPR = IPRoute()
 
+logger.create('nolog', 'info')
+LOG = logger.getlogger()
+PROFILE = 'profile.yml'
+
 
 class OSinstall(npyscreen.NPSAppManaged):
 
@@ -66,7 +70,7 @@ class OSinstall(npyscreen.NPSAppManaged):
                 if link.get_attr('IFLA_OPERSTATE') == 'UP':
                     link_name = link.get_attr('IFLA_IFNAME')
                     ifcs_up.append(link_name)
-                    #ifcs_state[link_name] = link.get_attr('IFLA_OPERSTATE')
+                    # ifcs_state[link_name] = link.get_attr('IFLA_OPERSTATE')
         return ifcs_up
 
     def onStart(self):
@@ -322,18 +326,29 @@ class OSinstall_form(npyscreen.Form):
                                              relx=relx)
             self.fields[item].entry_widget.add_handlers({curses.KEY_F1:
                                                         self.h_help})
-if __name__ == '__main__':
 
-    logger.create('nolog', 'info')
-    log = logger.getlogger()
 
-    profile = 'profile.yml'
+def validate(profile_tuple):
+    if profile_tuple.bmc_address_mode == "dhcp" or profile_tuple.pxe_address_mode == "dhcp":
+        hasDhcpServers = u.has_dhcp_servers(profile_tuple.ethernet_port)
+        if not hasDhcpServers:
+            LOG.warn("No Dhcp servers found on {0}".format(profile_tuple.ethernet_port))
+        else:
+            LOG.info("Dhcp servers found on {0}".format(profile_tuple.ethernet_port))
+
+
+def main():
     try:
         osi = OSinstall()
-        osi.load_profile(profile)
+        osi.load_profile(PROFILE)
         osi.run()
         p = osi.get_profile_tuple()
-        log.debug(p)
+        LOG.debug(p)
+        validate(p)
         print(p)
     except KeyboardInterrupt:
-        log.info("Exiting ...")
+        LOG.info("Exiting at user request")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/commit_message_validate.py
+++ b/tests/commit_message_validate.py
@@ -35,7 +35,8 @@ for i, line in enumerate(get_head_commit_message().splitlines()):
     if i == 0:
         if line.split()[0] not in valid_subject_tags:
             no_errors = False
-            errors.append("Subject line does not start with valid tag")
+            errors.append("\nSubject line does not start with valid tag\
+                          \nValid tags are:\n\t({0})".format(" ".join(valid_subject_tags)))
         if line.split()[0] not in ['Revert', 'Merge']:
             if len(line.split()) > 2 and line.split()[1][0].islower():
                 no_errors = False

--- a/tests/unit/test_pup_osinstall.py
+++ b/tests/unit/test_pup_osinstall.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# Copyright 2019 IBM Corp.
+#
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+from mock import patch as patch
+from lib import utilities as util
+from scripts.python import osinstall as installer
+from collections import namedtuple
+GOOD_NMAP_OUTPUT = """[sudo] password for jja:
+Starting Nmap 6.40 ( http://nmap.org ) at 2019-01-23 13:33 EST
+Pre-scan script results:
+| broadcast-dhcp-discover:
+|   IP Offered: 192.168.12.249
+|   DHCP Message Type: DHCPOFFER
+|   Server Identifier: 192.168.12.2
+|   IP Address Lease Time: 0 days, 0:02:00
+|   Renewal Time Value: 0 days, 0:01:00
+|   Rebinding Time Value: 0 days, 0:01:45
+|   Subnet Mask: 255.255.255.0
+|   Broadcast Address: 192.168.12.255
+|   Domain Name Server: 192.168.12.2
+|_  Router: 192.168.12.3
+WARNING: No targets were specified, so 0 hosts scanned.
+Nmap done: 0 IP addresses (0 hosts up) scanned in 3.07 seconds"""
+
+BAD_NMAP_OUTPUT = """
+Starting Nmap 6.40 ( http://nmap.org ) at 2019-01-23 15:17 EST
+WARNING: No targets were specified, so 0 hosts scanned.
+Nmap done: 0 IP addresses (0 hosts up) scanned in 10.15 seconds
+"""
+
+
+class TestScript(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestScript, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        super(TestScript, self).setUp()
+        self.root_p = patch('os.geteuid')
+        self.root = self.root_p.start()
+        # Pass future root checks
+        self.root.return_value = 0
+
+    def tearDown(self):
+        self.root_p.stop()
+
+    @patch("lib.utilities.get_dhcp_servers")
+    @patch("lib.utilities.bash_cmd")
+    @patch("lib.utilities.has_dhcp_servers")
+    def test_has_dhcp_servers(self, mock_get, mock_cmd, mock_has):
+        mock_cmd.return_value = GOOD_NMAP_OUTPUT
+        device = "ent1"
+        # good path
+        dct = util.parse_dhcp_servers(GOOD_NMAP_OUTPUT)
+        assert "DHCP Message Type" in dct and dct["DHCP Message Type"] == "DHCPOFFER"
+        dct = util.parse_dhcp_servers(BAD_NMAP_OUTPUT)
+        assert "DHCP Message Type" not in dct
+        # bad path
+        dct = util.get_dhcp_servers(device)
+        assert mock_cmd.called_once_with(device)
+        # erroneous device ... not found
+        util.has_dhcp_servers(device)
+        assert mock_get.called_once_with(device)
+        profile_tuple = namedtuple("profile_tuple", "bmc_vlan_number bmc_subnet_prefix bmc_address_mode ethernet_port")
+        profile_tuple = profile_tuple(bmc_vlan_number=12, bmc_subnet_prefix=24,
+                                      bmc_address_mode='dhcp', ethernet_port='br-pxe-12')
+        installer.validate(profile_tuple)
+        assert mock_has.called_once_with(profile_tuple.ethernet_port)


### PR DESCRIPTION
These patches add:

* keyboard exception handling in osinstall.py
* Check for existing dhcp servers given an interface using nmap