### PR TITLE
fix: Resolve 'CryptographyDeprecationWarning'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ansible==2.7.1
 ansible-vault==1.2.0
 click==7.0
+cryptography==2.4.2
 docker==3.5.1
 filelock==3.0.9
 gitpython==2.1.11


### PR DESCRIPTION
The 'paramiko' python module depends on the 'cryptography' module. There
is a known 'CryptographyDeprecationWarning' problem (see
https://github.com/paramiko/paramiko/issues/1369) that can be resolved
by installing 'cryptography==2.4.2'.