### PR TITLE
chore: Name Ansible task to pass 'ansible-lint'

### DIFF
--- a/playbooks/tasks/redhat_subscription.yml
+++ b/playbooks/tasks/redhat_subscription.yml
@@ -15,7 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- set_fact:
+- name: Load redhat_subscription parameters
+  set_fact:
      params: "{{ os['redhat_subscription'] }}"
   when: os['redhat_subscription'] is defined
 


### PR DESCRIPTION
Commit 2357dc7 failed to name one of the added tasks and causes the
'ansible-lint' tox test to fail.