### PR TITLE
fix: Only disable stale 'ifcfg' scripts

### DIFF
--- a/playbooks/lookup_interface_names.yml
+++ b/playbooks/lookup_interface_names.yml
@@ -70,12 +70,12 @@
   hosts: client_nodes
   gather_facts: True
   vars:
-    stale_devices: []
+    stale_devs: []
   tasks:
     - block:
         - name: Create list of PXE devices that will be renamed
           set_fact:
-            stale_devices: "{{ stale_devices + [mac_to_device[item.0]] }}"
+            stale_devs: "{{ stale_devs + [mac_to_device[item.0|lower]] }}"
           with_together:
             - "{{ vars['pxe']['macs'] }}"
             - "{{ vars['pxe']['rename'] }}"
@@ -83,11 +83,11 @@
           when:
             - item.0 is not none
             - item.1
-            - item.2 != mac_to_device[item.0]
+            - item.2 != mac_to_device[item.0|lower]
 
         - name: Create list of Data devices that will be renamed
           set_fact:
-            stale_devices: "{{ stale_devices + [mac_to_device[item.0]] }}"
+            stale_devs: "{{ stale_devs + [mac_to_device[item.0|lower]] }}"
           with_together:
             - "{{ vars['data']['macs'] }}"
             - "{{ vars['data']['rename'] }}"
@@ -95,7 +95,7 @@
           when:
             - item.0 is not none
             - item.1
-            - item.2 != mac_to_device[item.0]
+            - item.2 != mac_to_device[item.0|lower]
 
         - name: Find all interface configuration scripts
           find:
@@ -110,7 +110,7 @@
             line: 'ONBOOT=no  # Disabled by POWER-Up'
           when:
             - (item.path | basename).split('-')[1] != 'lo'
-            - (item.path | basename).split('-')[1] in stale_devices
+            - (item.path | basename).split('-')[1] in stale_devs
           loop: "{{ ifcfg_scripts.files }}"
       when: (ansible_distribution == 'CentOS' or
              ansible_distribution == 'RedHat')

--- a/playbooks/lookup_interface_names.yml
+++ b/playbooks/lookup_interface_names.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2018 IBM Corp.
+# Copyright 2019 IBM Corp.
 #
 # All Rights Reserved.
 #
@@ -65,4 +65,53 @@
                 {{ scripts_path }}/python/inv_set_interface_names.py \
                 {{ item.key }} {{ item.value }} {{ config_path }}"
       with_dict: "{{ set_macs_all }}"
+
+- name: Disable any ifcfg scripts that will become stale after renames
+  hosts: client_nodes
+  gather_facts: True
+  vars:
+    stale_devices: []
+  tasks:
+    - block:
+        - name: Create list of PXE devices that will be renamed
+          set_fact:
+            stale_devices: "{{ stale_devices + [mac_to_device[item.0]] }}"
+          with_together:
+            - "{{ vars['pxe']['macs'] }}"
+            - "{{ vars['pxe']['rename'] }}"
+            - "{{ vars['pxe']['devices'] }}"
+          when:
+            - item.0 is not none
+            - item.1
+            - item.2 != mac_to_device[item.0]
+
+        - name: Create list of Data devices that will be renamed
+          set_fact:
+            stale_devices: "{{ stale_devices + [mac_to_device[item.0]] }}"
+          with_together:
+            - "{{ vars['data']['macs'] }}"
+            - "{{ vars['data']['rename'] }}"
+            - "{{ vars['data']['devices'] }}"
+          when:
+            - item.0 is not none
+            - item.1
+            - item.2 != mac_to_device[item.0]
+
+        - name: Find all interface configuration scripts
+          find:
+            paths: /etc/sysconfig/network-scripts/
+            patterns: 'ifcfg-*'
+          register: ifcfg_scripts
+
+        - name: Disable any interface scripts that will become stale
+          lineinfile:
+            path: "{{ item.path }}"
+            regexp: '^ONBOOT='
+            line: 'ONBOOT=no  # Disabled by POWER-Up'
+          when:
+            - (item.path | basename).split('-')[1] != 'lo'
+            - (item.path | basename).split('-')[1] in stale_devices
+          loop: "{{ ifcfg_scripts.files }}"
+      when: (ansible_distribution == 'CentOS' or
+             ansible_distribution == 'RedHat')
 ...

--- a/playbooks/tasks/create_interfaces.yml
+++ b/playbooks/tasks/create_interfaces.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2018 IBM Corp.
+# Copyright 2019 IBM Corp.
 #
 # All Rights Reserved.
 #
@@ -71,23 +71,5 @@
     backup: no
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
   with_items: "{{ interfaces }}"
-
-- name: Find all interface configuration scripts
-  find:
-    paths: /etc/sysconfig/network-scripts/
-    patterns: 'ifcfg-*'
-  register: ifcfg_scripts
-
-- name: Disable any interfaces not defined in inventory
-  lineinfile:
-    path: "{{ item.path }}"
-    regexp: '^ONBOOT='
-    line: 'ONBOOT=no  # Disabled by POWER-Up'
-  when:
-    - ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
-    - (item.path | basename).split('-')[1] != 'lo'
-    - (item.path | basename).split('-')[1] not in pxe.devices
-    - (item.path | basename).split('-')[1] not in data.devices
-  loop: "{{ ifcfg_scripts.files }}"
 
 ...


### PR DESCRIPTION
Commit 28743e1 (PR #323) disabled "ONBOOT" loading of _any_ ifcfg script
with a device name that didn't match a physical device name in
inventory. This commit changes the logic to _only_ disable "ONBOOT" in
ifcfg names match the original device name of a *changed* interface. All
other interface configuration scripts are left alone.