### PR TITLE
refactor: Fix tox errors

### DIFF
--- a/scripts/python/configure_mgmt_switches.py
+++ b/scripts/python/configure_mgmt_switches.py
@@ -82,9 +82,7 @@ def configure_mgmt_switches(config_file=None):
                     'Switch authentication via ssh keys not yet supported')
 
         if mode == PASSIVE:
-                sw = SwitchFactory.factory(
-                    switch_class,
-                    mode)
+            sw = SwitchFactory.factory(switch_class, mode)
 
         elif mode == ACTIVE:
             # Try all ipaddrs in switches.interfaces

--- a/scripts/python/repos.py
+++ b/scripts/python/repos.py
@@ -154,24 +154,24 @@ def get_name_dir(name):
 
 
 def powerup_file_from_disk(name, file_glob):
-        log = logger.getlogger()
-        name_src = get_name_dir(name)
-        dest_path = None
-        src_path = get_src_path(file_glob)
-        if src_path:
-            if not os.path.exists(f'/srv/{name_src}'):
-                os.mkdir(f'/srv/{name_src}')
-            try:
-                copy2(src_path, f'/srv/{name_src}/')
-            except Error as err:
-                log.debug(f'Failed copying {name} source file to /srv/{name_src}/ '
-                          f'directory. \n{err}')
-            else:
-                log.info(f'Successfully installed {name} source file '
-                         'into the POWER-Up software server.')
-                dest_path = os.path.join(f'/srv/{name_src}/',
-                                         os.path.basename(src_path))
-        return src_path, dest_path
+    log = logger.getlogger()
+    name_src = get_name_dir(name)
+    dest_path = None
+    src_path = get_src_path(file_glob)
+    if src_path:
+        if not os.path.exists(f'/srv/{name_src}'):
+            os.mkdir(f'/srv/{name_src}')
+        try:
+            copy2(src_path, f'/srv/{name_src}/')
+        except Error as err:
+            log.debug(f'Failed copying {name} source file to /srv/{name_src}/ '
+                      f'directory. \n{err}')
+        else:
+            log.info(f'Successfully installed {name} source file '
+                     'into the POWER-Up software server.')
+            dest_path = os.path.join(f'/srv/{name_src}/',
+                                     os.path.basename(src_path))
+    return src_path, dest_path
 
 
 class PowerupRepo(object):

--- a/scripts/python/show_mgmt_switches.py
+++ b/scripts/python/show_mgmt_switches.py
@@ -152,15 +152,15 @@ def print_lines(str, line_list):
 def get_int_input(prompt_str, minn, maxx):
     while 1:
         try:
-            input = int(input(prompt_str))
-            if not (minn <= input <= maxx):
+            _input = int(input(prompt_str))
+            if not (minn <= _input <= maxx):
                 raise ValueError()
             else:
                 break
         except ValueError:
             print("enter an integer between " +
                   str(minn) + ' and ' + str(maxx))
-    return input
+    return _input
 
 
 if __name__ == '__main__':

--- a/scripts/python/show_status.py
+++ b/scripts/python/show_status.py
@@ -153,15 +153,15 @@ def print_lines(str, line_list):
 def get_int_input(prompt_str, minn, maxx):
     while 1:
         try:
-            input = int(input(prompt_str))
-            if not (minn <= input <= maxx):
+            _input = int(input(prompt_str))
+            if not (minn <= _input <= maxx):
                 raise ValueError()
             else:
                 break
         except ValueError:
             print("enter an integer between " +
                   str(minn) + ' and ' + str(maxx))
-    return input
+    return _input
 
 
 if __name__ == '__main__':

--- a/software/get-dependent-packages.sh
+++ b/software/get-dependent-packages.sh
@@ -46,8 +46,8 @@ echo
 # files to it directly without creating puptempdl dir under it.
 rm -rf ~/tempdl
 
-sshpass -e ssh -t $1@$2 'mkdir -p ~/puptempdl && sudo yumdownloader --archlist=ppc64le \
-    --resolve --destdir ~/puptempdl '$pkglist
+sshpass -e ssh -t $1@$2 'mkdir -p ~/puptempdl && sudo yumdownloader \
+    --archlist=ppc64le --resolve --destdir ~/puptempdl '$pkglist
 
 echo Retrieving packages
 sshpass -e scp -r $1@$2:~/puptempdl/ ~/tempdl


### PR DESCRIPTION
This cleans up the remaining tox errors in master branch:

- software/get-dependent-packages.sh:50:1: E006 Line too long
- scripts/python/show_status.py:156:25: F823 local variable 'input'
    defined as a builtin referenced before assignment
- scripts/python/repos.py:157:9: E117 over-indented
- scripts/python/configure_mgmt_switches.py:85:17: E117 over-indented
- scripts/python/show_mgmt_switches.py:155:25: F823 local variable
    'input' defined as a builtin referenced before assignment