### PR TITLE
fix: Remove "continue" line from lenovo switch out

### DIFF
--- a/scripts/python/lib/lenovo.py
+++ b/scripts/python/lib/lenovo.py
@@ -119,6 +119,8 @@ class Lenovo(SwitchCommon):
             for line in port_info:
                 # pad to 86 chars
                 line = f'{line:<86}'
+                # remove "Press q to quit, any other key to continue" line
+                line = re.sub('\\x1b.*\\x08', '', line)
                 # look for rows (look for first few fields)
                 match = re.search(r'^\s*\w+\s+\d+\s+(y|n)', line)
                 if match:


### PR DESCRIPTION
When reading port information from a lenovo switch the output is split
to allow viewing one page at a time (similar to unix 'more'). Port 26 is
listed after the "continue" text which caused the parser to drop the
data.