### PR TITLE
refactor: Update Ubuntu installer image URLs

### DIFF
--- a/os-images/os-image-urls.yml
+++ b/os-images/os-image-urls.yml
@@ -20,14 +20,14 @@ os_image_urls:
     images:
       - url: http://releases.ubuntu.com/14.04.5/ubuntu-14.04.5-server-amd64.iso
         sha1sum: 5e567024c385cc8f90c83d6763c6e4f1cd5deb6f
-  - name: ubuntu-16.04.5-server-amd64
+  - name: ubuntu-16.04.6-server-amd64
     images:
-      - url: http://releases.ubuntu.com/16.04/ubuntu-16.04.5-server-amd64.iso
-        sha1sum: ee32c555567dd5407c58a1cfc7e668ab37a99d99
-  - name: ubuntu-16.04.5-server-ppc64el
+      - url: http://releases.ubuntu.com/16.04/ubuntu-16.04.6-server-amd64.iso
+        sha1sum: 056b7c15efc15bbbf40bf1a9ff1a3531fcbf70a2
+  - name: ubuntu-16.04.6-server-ppc64el
     images:
-      - url: http://cdimage.ubuntu.com/releases/16.04.5/release/ubuntu-16.04.5-server-ppc64el.iso
-        sha1sum: ccc734b96543e29127e0864bf88f17faea667100
+      - url: http://cdimage.ubuntu.com/releases/16.04.6/release/ubuntu-16.04.6-server-ppc64el.iso
+        sha1sum: 3c990f38646b7fbd75e560df52b60f0c37c6b7ab
   - name: ubuntu-18.04.2-live-server-amd64
     images:
       - url: http://releases.ubuntu.com/18.04/ubuntu-18.04.2-live-server-amd64.iso

--- a/os-images/os-image-urls.yml
+++ b/os-images/os-image-urls.yml
@@ -35,7 +35,7 @@ os_image_urls:
   - name: ubuntu-18.04.2-server-amd64
     images:
       - url: http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso
-        sha1sum: a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5
+        sha1sum: 57c3a25f2c5fd61596ce39afbff44dd49b0089a2
   - name: ubuntu-18.04.2-server-ppc64el
     images:
       - url: http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-ppc64el.iso

--- a/os-images/os-image-urls.yml
+++ b/os-images/os-image-urls.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2018 IBM Corp.
+# Copyright 2019 IBM Corp.
 #
 # All Rights Reserved.
 #
@@ -28,13 +28,13 @@ os_image_urls:
     images:
       - url: http://cdimage.ubuntu.com/releases/16.04.5/release/ubuntu-16.04.5-server-ppc64el.iso
         sha1sum: ccc734b96543e29127e0864bf88f17faea667100
-  - name: ubuntu-18.04.1-live-server-amd64
+  - name: ubuntu-18.04.2-live-server-amd64
     images: &1804amd64
-      - url: http://releases.ubuntu.com/18.04/ubuntu-18.04.1-live-server-amd64.iso
-        sha1sum: a1c3272c6cfc96e1d3024825fbe1e015e4350be4
-  - name: ubuntu-18.04.1-server-amd64
+      - url: http://releases.ubuntu.com/18.04/ubuntu-18.04.2-live-server-amd64.iso
+        sha1sum: aa9606eb8c0bbce00552907f541547c4c510134f
+  - name: ubuntu-18.04.2-server-amd64
     images: *1804amd64
-  - name: ubuntu-18.04.1-server-ppc64el
+  - name: ubuntu-18.04.2-server-ppc64el
     images:
-      - url: http://cdimage.ubuntu.com/releases/18.04.1/release/ubuntu-18.04.1-server-ppc64el.iso
-        sha1sum: 6be16a8a5c2cd2113e5bab8a676583c79c20cf02
+      - url: http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-ppc64el.iso
+        sha1sum: 96f4d7aebb86adcc4b8625eea43bf1c0b86364e1

--- a/os-images/os-image-urls.yml
+++ b/os-images/os-image-urls.yml
@@ -28,10 +28,6 @@ os_image_urls:
     images:
       - url: http://cdimage.ubuntu.com/releases/16.04.6/release/ubuntu-16.04.6-server-ppc64el.iso
         sha1sum: 3c990f38646b7fbd75e560df52b60f0c37c6b7ab
-  - name: ubuntu-18.04.2-live-server-amd64
-    images:
-      - url: http://releases.ubuntu.com/18.04/ubuntu-18.04.2-live-server-amd64.iso
-        sha1sum: aa9606eb8c0bbce00552907f541547c4c510134f
   - name: ubuntu-18.04.2-server-amd64
     images:
       - url: http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso

--- a/os-images/os-image-urls.yml
+++ b/os-images/os-image-urls.yml
@@ -29,11 +29,13 @@ os_image_urls:
       - url: http://cdimage.ubuntu.com/releases/16.04.5/release/ubuntu-16.04.5-server-ppc64el.iso
         sha1sum: ccc734b96543e29127e0864bf88f17faea667100
   - name: ubuntu-18.04.2-live-server-amd64
-    images: &1804amd64
+    images:
       - url: http://releases.ubuntu.com/18.04/ubuntu-18.04.2-live-server-amd64.iso
         sha1sum: aa9606eb8c0bbce00552907f541547c4c510134f
   - name: ubuntu-18.04.2-server-amd64
-    images: *1804amd64
+    images:
+      - url: http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso
+        sha1sum: a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5
   - name: ubuntu-18.04.2-server-ppc64el
     images:
       - url: http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.2-server-ppc64el.iso

--- a/scripts/python/cobbler_add_distros.py
+++ b/scripts/python/cobbler_add_distros.py
@@ -122,20 +122,17 @@ def cobbler_add_distro(path, name):
         for item in name_list:
             if item == 'amd64':
                 arch = 'x86_64'
-                kernel = (
-                    "%s/install/netboot/ubuntu-installer/amd64/linux" %
-                    path)
-                initrd = (
-                    "%s/install/netboot/ubuntu-installer/amd64/initrd.gz" %
-                    path)
+                subdir = "install/netboot/ubuntu-installer/amd64"
+                kernel = f"{path}/{subdir}/linux"
+                initrd = f"{path}/{subdir}/initrd.gz"
+                if not os.path.isfile(kernel):
+                    kernel = f"{path}/casper/vmlinuz"
+                    initrd = f"{path}/casper/initrd"
             elif item == 'ppc64el':
                 arch = 'ppc64le'
-                kernel = (
-                    "%s/install/netboot/ubuntu-installer/ppc64el/vmlinux"
-                    % path)
-                initrd = (
-                    "%s/install/netboot/ubuntu-installer/ppc64el/initrd.gz"
-                    % path)
+                subdir = "install/netboot/ubuntu-installer/ppc64el"
+                kernel = f"{path}/{subdir}/vmlinux"
+                initrd = f"{path}/{subdir}/initrd.gz"
             elif item.startswith('14.04'):
                 os_version = 'trusty'
             elif item.startswith('16.04'):

--- a/scripts/python/lib/genesis.py
+++ b/scripts/python/lib/genesis.py
@@ -286,9 +286,9 @@ def get_os_profile_pointers():
         "ubuntu-14.04-server-amd64": "ubuntu-14.04.5-server-amd64",
         "ubuntu-16.04-server-amd64": "ubuntu-16.04.5-server-amd64",
         "ubuntu-16.04-server-ppc64el": "ubuntu-16.04.5-server-ppc64el",
-        "ubuntu-18.04-live-server-amd64": "ubuntu-18.04.1-live-server-amd64",
-        "ubuntu-18.04-server-amd64": "ubuntu-18.04.1-server-amd64",
-        "ubuntu-18.04-server-ppc64el": "ubuntu-18.04.1-server-ppc64el"}
+        "ubuntu-18.04-live-server-amd64": "ubuntu-18.04.2-live-server-amd64",
+        "ubuntu-18.04-server-amd64": "ubuntu-18.04.2-server-amd64",
+        "ubuntu-18.04-server-ppc64el": "ubuntu-18.04.2-server-ppc64el"}
 
 
 def check_os_profile(profile):

--- a/scripts/python/lib/genesis.py
+++ b/scripts/python/lib/genesis.py
@@ -284,8 +284,8 @@ def get_dhcp_pool_start():
 def get_os_profile_pointers():
     return {
         "ubuntu-14.04-server-amd64": "ubuntu-14.04.5-server-amd64",
-        "ubuntu-16.04-server-amd64": "ubuntu-16.04.5-server-amd64",
-        "ubuntu-16.04-server-ppc64el": "ubuntu-16.04.5-server-ppc64el",
+        "ubuntu-16.04-server-amd64": "ubuntu-16.04.6-server-amd64",
+        "ubuntu-16.04-server-ppc64el": "ubuntu-16.04.6-server-ppc64el",
         "ubuntu-18.04-live-server-amd64": "ubuntu-18.04.2-live-server-amd64",
         "ubuntu-18.04-server-amd64": "ubuntu-18.04.2-server-amd64",
         "ubuntu-18.04-server-ppc64el": "ubuntu-18.04.2-server-ppc64el"}

--- a/scripts/python/lib/genesis.py
+++ b/scripts/python/lib/genesis.py
@@ -286,7 +286,6 @@ def get_os_profile_pointers():
         "ubuntu-14.04-server-amd64": "ubuntu-14.04.5-server-amd64",
         "ubuntu-16.04-server-amd64": "ubuntu-16.04.6-server-amd64",
         "ubuntu-16.04-server-ppc64el": "ubuntu-16.04.6-server-ppc64el",
-        "ubuntu-18.04-live-server-amd64": "ubuntu-18.04.2-live-server-amd64",
         "ubuntu-18.04-server-amd64": "ubuntu-18.04.2-server-amd64",
         "ubuntu-18.04-server-ppc64el": "ubuntu-18.04.2-server-ppc64el"}
 


### PR DESCRIPTION
Ubuntu 18.04 URLs (and checksums) have been updated to point to the
18.04.1 images.