### PR TITLE
fix: Copy 'os-images' content one item at a time

### DIFF
--- a/scripts/python/gen.py
+++ b/scripts/python/gen.py
@@ -275,7 +275,6 @@ class Gen(object):
         except FileNotFoundError as exc:
             log.debug(f'Unable to create copy of config file. {exc}')
 
-
     def _install_cobbler(self):
         from lib.container import Container
 
@@ -304,11 +303,13 @@ class Gen(object):
         cont = Container(self.config_file_path)
         local_os_images = gen.get_os_images_path()
         cont_os_images = gen.get_container_os_images_path()
-        try:
-            cont.copy(local_os_images, cont_os_images)
-        except UserException as exc:
-            print('Fail:', str(exc), file=sys.stderr)
-            sys.exit(1)
+        for item in os.listdir(local_os_images):
+            try:
+                cont.copy(os.path.join(local_os_images, item),
+                          os.path.join(cont_os_images, item))
+            except UserException as exc:
+                print('Fail:', str(exc), file=sys.stderr)
+                sys.exit(1)
         print('Success: OS images downloaded and copied into container')
 
     def _inv_add_ports_ipmi(self):


### PR DESCRIPTION
The contents of the 'os-images' directory are archived and copied into
the container. The archive can become quite large if multiple OS images
are present. The files and directories can be copied one at a time to
reduce the total memory required to load the archive.