### PR TITLE
refactor: Improve Ubuntu data MAC collection

### DIFF
--- a/playbooks/activate_client_interfaces.yml
+++ b/playbooks/activate_client_interfaces.yml
@@ -61,12 +61,25 @@
         create: True
 
     - name: Update switch mac address tables
-      shell: "dhclient -r && dhclient {{ item }} -1 || true"
+      shell: "dhclient -r && dhclient -n -1 {{ item }} || true"
       become: true
       when:
         - item != 'lo'
         - "ansible_host != hostvars[inventory_hostname]['ansible_' + \
            item.replace('-', '_')].get('ipv4', {}).get('address')"
+        - ansible_distribution == 'Ubuntu'
+      loop: "{{ ansible_interfaces }}"
+      environment:
+        PATH_DHCLIENT_CONF: /run/dhclient.conf
+
+    - name: Update switch mac address tables
+      shell: "dhclient -r && dhclient -1 {{ item }} || true"
+      become: true
+      when:
+        - item != 'lo'
+        - "ansible_host != hostvars[inventory_hostname]['ansible_' + \
+           item.replace('-', '_')].get('ipv4', {}).get('address')"
+        - ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
       loop: "{{ ansible_interfaces }}"
       environment:
         PATH_DHCLIENT_CONF: /run/dhclient.conf


### PR DESCRIPTION
Add '-n' dhclient option to client nodes running Ubuntu to speed up data
MAC address collection. This option prevents the interface from
accepting a DHCP lease (for some reason it causes 'dhclient' to hang in
RHEL).