### PR TITLE
fix: Set siwtches in inventory

### DIFF
--- a/scripts/python/lib/inventory.py
+++ b/scripts/python/lib/inventory.py
@@ -249,6 +249,7 @@ class Inventory(object):
         self.dbase.dump_inventory(self.inv)
 
     def update_switches(self):
+        switches = []
         self.inv.switches = switches
         self.dbase.dump_inventory(self.inv)
 


### PR DESCRIPTION
Set switches to empty list in inventory to prevent error msg.
This is a place older for switches in inventory.