### PR TITLE
fix: Convert relative config path to absolute

### DIFF
--- a/scripts/python/lib/container.py
+++ b/scripts/python/lib/container.py
@@ -370,6 +370,7 @@ class Container(object):
     def copy(self, source_path, cont_dest_path):
         self.log.debug(f"Copy '{source_path}' into "
                        f"'{self.cont.name}:{cont_dest_path}'")
+        orig_cwd = os.getcwd()
         os.chdir(os.path.dirname(source_path))
         source_base = os.path.basename(source_path)
 
@@ -381,3 +382,4 @@ class Container(object):
             os.remove(source_path + '.tar')
         else:
             self.log.error("Container 'put_archive' error!")
+        os.chdir(orig_cwd)

--- a/scripts/python/lib/db.py
+++ b/scripts/python/lib/db.py
@@ -49,6 +49,8 @@ class DatabaseConfig(object):
         """
 
         if not os.path.isfile(config_file):
+            if os.path.isfile(os.path.join(gen.GEN_PATH, config_file)):
+                self.cfg = os.path.join(gen.GEN_PATH, config_file)
             msg = 'Could not find config file: ' + config_file
             self.log.error(msg)
             raise UserException(msg)


### PR DESCRIPTION
The 'DatabaseConfig' class will accept a relative config file path
without controlling the current working directory. If the python working
directory is changed then a previously valid relative config path can
become invalid (see next paragraph). If a path is invalid it's worth
joining it with the project root directory and checking again.

The 'Container' class 'copy' method changes the working directory
without cleaning up after itself.