### PR TITLE
feat: Use profile template if none specified

### DIFF
--- a/scripts/python/gen.py
+++ b/scripts/python/gen.py
@@ -571,7 +571,8 @@ class Gen(object):
             else:
                 self.config_file_path += self.args.config_file_name
 
-            if not os.path.isfile(self.config_file_path):
+            if (not self.args.osinstall and
+                not os.path.isfile(self.config_file_path)):
                 print('{} not found. Please specify a file name'.format(
                     self.config_file_path))
                 sys.exit(1)

--- a/scripts/python/gen.py
+++ b/scripts/python/gen.py
@@ -571,8 +571,8 @@ class Gen(object):
             else:
                 self.config_file_path += self.args.config_file_name
 
-            if (not self.args.osinstall and
-                not os.path.isfile(self.config_file_path)):
+            if (not hasattr(self.args, 'osinstall') and
+                    not os.path.isfile(self.config_file_path)):
                 print('{} not found. Please specify a file name'.format(
                     self.config_file_path))
                 sys.exit(1)


### PR DESCRIPTION
If invoking osinstall from pup, use sample-configs/
profile-template as the profile when no profile.yml exists.