### PR TITLE
fix: Add switch class 'sanitize_line' method

### DIFF
--- a/scripts/python/lib/lenovo.py
+++ b/scripts/python/lib/lenovo.py
@@ -117,10 +117,9 @@ class Lenovo(SwitchCommon):
             indcs = get_col_pos(port_info, ('Port', 'Tag', 'PVID', r'VLAN\(s'))
             port_info = port_info.splitlines()
             for line in port_info:
+                line = self.sanitize_line(line)
                 # pad to 86 chars
                 line = f'{line:<86}'
-                # remove "Press q to quit, any other key to continue" line
-                line = re.sub('\\x1b.*\\x08', '', line)
                 # look for rows (look for first few fields)
                 match = re.search(r'^\s*\w+\s+\d+\s+(y|n)', line)
                 if match:
@@ -262,6 +261,12 @@ class Lenovo(SwitchCommon):
             raise SwitchException(
                 'Failed configuring management interface ip {}'.format(intf))
         return
+
+    @staticmethod
+    def sanitize_line(line):
+        # remove "Press q to quit, any other key to continue" line
+        line = re.sub('\\x1b.*\\x08', '', line)
+        return line
 
 
 class switch(object):

--- a/scripts/python/lib/switch_common.py
+++ b/scripts/python/lib/switch_common.py
@@ -416,8 +416,7 @@ class SwitchCommon(object):
             self.log.error('Unable to ping switch.  {}'.format(exc))
             return False
 
-    @staticmethod
-    def get_port_to_mac(mac_address_table, fmt='std', port_prefix=' '):
+    def get_port_to_mac(self, mac_address_table, fmt='std', port_prefix=' '):
         """Convert MAC address table to dictionary.
 
         Args:
@@ -461,6 +460,7 @@ class SwitchCommon(object):
             match = _mac_regex.search(line)
 
             if match:
+                line = self.sanitize_line(line)
                 mac = match.group()
                 log.debug('Found mac address: {}'.format(mac))
                 _mac = mac
@@ -478,6 +478,10 @@ class SwitchCommon(object):
                 else:
                     mac_dict[port].append(_mac)
         return mac_dict
+
+    @staticmethod
+    def sanitize_line(line):
+        return line
 
     def enable_lacp(self):
         self.send_cmd(self.ENABLE_LACP)


### PR DESCRIPTION
Lenovo switches add extraneous characters for line paging. A class
method is added to allow unique sanitation logic for each vendor switch
class.