### PR TITLE
fix: Call inventory update methods directly

### DIFF
--- a/scripts/python/inv_create.py
+++ b/scripts/python/inv_create.py
@@ -37,9 +37,11 @@ class InventoryCreate(object):
 
         nodes = InventoryNodes(cfg_path=self.config_path)
         nodes.create_nodes()
+        nodes.inv.update_nodes()
 
         switches = InventorySwitches(cfg_path=self.config_path)
         switches.create_switches()
+        nodes.inv.update_switches()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The same inventory file is used to store 'InventoryNodes' and
'InventorySwitches' class data. Existing content is loaded from file
(_not_ from any existing objects). The 'update_' method can be called to
write data to file without relying on object deletion and allowing for
subsequent 'InventoryNodes' or 'InventorySwitches' objects to loaded
current content.