### PR TITLE
fix issue 7619 of missing package

### DIFF
--- a/software/pkg-lists-wmla120.yml
+++ b/software/pkg-lists-wmla120.yml
@@ -89,7 +89,6 @@ anaconda_main_linux_ppc64le:
     - functools32-3.2.3.2-py27_1.tar.bz2
     - future-0.17.1-py27_0.tar.bz2
     - future-0.17.1-py36_0.tar.bz2
-    - futures-3.2.0-py27_0.tar.bz2
     - gast-0.2.2-py27_0.tar.bz2
     - gast-0.2.2-py36_0.tar.bz2
     - get_terminal_size-1.0.0-0.tar.bz2

--- a/software/pkg-lists-wmla120.yml
+++ b/software/pkg-lists-wmla120.yml
@@ -89,6 +89,7 @@ anaconda_main_linux_ppc64le:
     - functools32-3.2.3.2-py27_1.tar.bz2
     - future-0.17.1-py27_0.tar.bz2
     - future-0.17.1-py36_0.tar.bz2
+    - futures-3.2.0-py27_0.tar.bz2
     - gast-0.2.2-py27_0.tar.bz2
     - gast-0.2.2-py36_0.tar.bz2
     - get_terminal_size-1.0.0-0.tar.bz2
@@ -323,7 +324,7 @@ python_pkgs:
     - Flask-Script==2.0.5
     - funcsigs==1.0.2
     - functools32==3.2.3.post2
-    - futures==3.2.0
+    - futures==3.1.1
     - gensim==3.6.0
     - hanziconv==0.3.2
     - idna==2.5


### PR DESCRIPTION
Changed package to an older package in pip list also added from list in conda main package. Seems there is another bug in parsing of correct data from the parser package tool.