### PR TITLE
fix: Additional detail in msg post Ansible ping

### DIFF
--- a/scripts/python/software_hosts.py
+++ b/scripts/python/software_hosts.py
@@ -415,8 +415,11 @@ def _validate_ansible_ping(software_hosts_file_path, hosts_list):
                 return _validate_ansible_ping(software_hosts_file_path,
                                               hosts_list)
         elif 'Permission denied' in msg:
-            print('"Permission denied" detected')
-            if get_yesno('Configure Client Nodes for SSH Key Access? '):
+            msg = ('The PowerUp software installer attempted to log into the '
+                   'the client node(s) but was unsuccessful. SSH key access may '
+                   'need to be configured.\n')
+            print(msg)
+            if get_yesno('OK to configure Client Nodes for SSH Key Access? '):
                 configure_ssh_keys(software_hosts_file_path)
                 return _validate_ansible_ping(software_hosts_file_path,
                                               hosts_list)


### PR DESCRIPTION
When software_hosts attempts to Ansible ping client nodes and is
unsuccesul, the displayed msg was being misinterpreted as a possible
error. A new message with greater detail is now displayed.