### PR TITLE
fix: Return relative paths in 'extract_iso_image'

### DIFF
--- a/scripts/python/cobbler_add_distros.py
+++ b/scripts/python/cobbler_add_distros.py
@@ -61,7 +61,9 @@ def extract_iso_images(path, html_dir):
         if _file.endswith('.iso'):
             kernel, initrd = util.extract_iso_image(path + _file, html_dir)
             name = _file[:-4]
-            return_list.append((name, kernel, initrd))
+            return_list.append((name,
+                                os.path.join(html_dir, kernel),
+                                os.path.join(html_dir, initrd)))
 
     return return_list
 

--- a/scripts/python/lib/utilities.py
+++ b/scripts/python/lib/utilities.py
@@ -1397,9 +1397,9 @@ def extract_iso_image(iso_path, dest_dir):
         kernel = os.path.join(name, sub_path, 'vmlinuz')
         initrd = os.path.join(name, sub_path, 'initrd.img')
 
-    if not os.path.isfile(kernel):
+    if not os.path.isfile(os.path.join(dest_dir, kernel)):
         kernel = None
-    if not os.path.isfile(initrd):
+    if not os.path.isfile(os.path.join(dest_dir, initrd)):
         initrd = None
 
     # If kernel or initrd isn't in the above matrix search for them

--- a/scripts/python/lib/utilities.py
+++ b/scripts/python/lib/utilities.py
@@ -1376,26 +1376,26 @@ def extract_iso_image(iso_path, dest_dir):
     initrd = None
     if {'ubuntu', 'amd64'}.issubset(filename_parsed):
         sub_path = 'install/netboot/ubuntu-installer/amd64'
-        kernel = os.path.join(iso_dir, sub_path, 'linux')
-        initrd = os.path.join(iso_dir, sub_path, 'initrd.gz')
+        kernel = os.path.join(name, sub_path, 'linux')
+        initrd = os.path.join(name, sub_path, 'initrd.gz')
         if not os.path.isfile(kernel):
             sub_path = 'casper'
-            kernel = os.path.join(iso_dir, sub_path, 'vmlinux')
-            initrd = os.path.join(iso_dir, sub_path, 'initrd')
+            kernel = os.path.join(name, sub_path, 'vmlinux')
+            initrd = os.path.join(name, sub_path, 'initrd')
     elif {'ubuntu', 'ppc64el'}.issubset(filename_parsed):
         sub_path = 'install/netboot/ubuntu-installer/ppc64el'
-        kernel = os.path.join(iso_dir, sub_path, 'vmlinux')
-        initrd = os.path.join(iso_dir, sub_path, 'initrd.gz')
+        kernel = os.path.join(name, sub_path, 'vmlinux')
+        initrd = os.path.join(name, sub_path, 'initrd.gz')
     elif ({'rhel', 'x86_64'}.issubset(filename_parsed) or
             {'centos', 'x86_64'}.issubset(filename_parsed)):
         sub_path = 'images/pxeboot'
-        kernel = os.path.join(iso_dir, sub_path, 'vmlinuz')
-        initrd = os.path.join(iso_dir, sub_path, 'initrd.img')
+        kernel = os.path.join(name, sub_path, 'vmlinuz')
+        initrd = os.path.join(name, sub_path, 'initrd.img')
     elif ({'rhel', 'ppc64le'}.issubset(filename_parsed) or
             {'centos', 'ppc64le'}.issubset(filename_parsed)):
         sub_path = 'ppc/ppc64'
-        kernel = os.path.join(iso_dir, sub_path, 'vmlinuz')
-        initrd = os.path.join(iso_dir, sub_path, 'initrd.img')
+        kernel = os.path.join(name, sub_path, 'vmlinuz')
+        initrd = os.path.join(name, sub_path, 'initrd.img')
 
     if not os.path.isfile(kernel):
         kernel = None


### PR DESCRIPTION
The 'extract_iso_image' utility function needs to return relative kernel
and initrd paths. The caller can then join the relative paths to a local
directory path (for Cobbler setup) or an http URL (to directly setup a
pxelinux configuration).