### PR TITLE
fix: Issue 8216, PyYAML 5.1 is failing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ pyroute2==0.5.3
 pysnmp==4.4.6
 tabulate==0.8.2
 wget==3.2
+PyYAML==3.13 # do not change this

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ pep8>=1.7.1
 pylint>=2.1.1
 testrepository>=0.0.20  # Apache-2.0/BSD
 pexpect==4.6.0
+PyYAML==3.13 # do not change this

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,3 @@ pep8>=1.7.1
 pylint>=2.1.1
 testrepository>=0.0.20  # Apache-2.0/BSD
 pexpect==4.6.0
-PyYAML==3.13 # do not change this


### PR DESCRIPTION
PyYAML 5.1 is failing to load tag !vault. Reverting to 3.11 in requirements.