### PR TITLE
fix: Handle 'no' response in pypi repo setup

### DIFF
--- a/software/wmla120.py
+++ b/software/wmla120.py
@@ -1058,7 +1058,7 @@ class software(object):
         ch = repo.get_action(exists, exists_prompt_yn=True)
 
         pkg_list = ' '.join(self.pkgs['python_pkgs'])
-        if not exists or ch == 'Y':
+        if not exists and ch == 'Y':
             pkg_list = ' '.join(self.pkgs['python_pkgs'])
             pkg3_list = ' '.join(self.pkgs['python3_specific_pkgs'])
             url = repo.get_repo_url(baseurl, alt_url, name=repo_name,


### PR DESCRIPTION
Skip creation of pypi repo when user responds no.