### PR TITLE
fix: Prevent P9 package sync from P8 installer

### DIFF
--- a/scripts/python/lib/utilities.py
+++ b/scripts/python/lib/utilities.py
@@ -1533,3 +1533,17 @@ def parse_rpm_filenames(filename):
         basename = version = None
 
     return basename, version
+
+
+def lscpu():
+    """ Get 'lscpu' output as dictionary
+
+    Returns:
+        dict: Output from 'lscpu'
+    """
+    stdout, stderr, returncode = sub_proc_exec('lscpu')
+    lscpu_dict = {}
+    for line in stdout.splitlines():
+        split = line.split(':', 1)
+        lscpu_dict[split[0].strip()] = split[1].strip()
+    return lscpu_dict


### PR DESCRIPTION
When setting up the dependencies repository the user selects to sync
either P8 or P9 packages. If and _only if_ the installer is running the
same model processor the packages can be synced from locally enabled yum
repositories. This commit removes the option to sync from enabled repositories
when the installer and client nodes do not have the same model of POWER 
processors.