### PR TITLE
fix: Add packages to pkg-lists

### DIFF
--- a/software/pkg-lists-wmla120.yml
+++ b/software/pkg-lists-wmla120.yml
@@ -550,6 +550,7 @@ yum_pkgs_p8:
 # resolution
     - wget
     - ntp
+    - nfs-utils
 yum_pkgs_p9:
     - adwaita-cursor-theme-3.28.0-1.el7.noarch
     - adwaita-icon-theme-3.28.0-1.el7.noarch
@@ -667,6 +668,7 @@ yum_pkgs_p9:
 # # resolution
     - wget
     - ntp
+    - nfs-utils
 cuda_drivers:
     - cuda-10-1-10.1.105-1
     - cuda-10.1.105-1

--- a/software/pkg-lists-wmla120.yml
+++ b/software/pkg-lists-wmla120.yml
@@ -545,6 +545,11 @@ yum_pkgs_p8:
     - xorg-x11-xkb-utils-7.7-14.el7.ppc64le
     - yum-utils-1.1.31-50.el7.noarch
     - zlib-devel-1.2.7-18.el7.ppc64le
+# Do not remove the additional packages below. They are included
+# in the pup kickstart and are thus not detected in package dependency
+# resolution
+    - wget
+    - ntp
 yum_pkgs_p9:
     - adwaita-cursor-theme-3.28.0-1.el7.noarch
     - adwaita-icon-theme-3.28.0-1.el7.noarch
@@ -657,6 +662,11 @@ yum_pkgs_p9:
     - xorg-x11-xkb-utils-7.7-14.el7.ppc64le
     - yum-utils-1.1.31-50.el7.noarch
     - zlib-devel-1.2.7-18.el7.ppc64le
+# Do not remove the additional packages below. They are included
+# # in the pup kickstart and are thus not detected in package dependency
+# # resolution
+    - wget
+    - ntp
 cuda_drivers:
     - cuda-10-1-10.1.105-1
     - cuda-10.1.105-1

--- a/software/pkg-lists-wmla120_x86_64.yml
+++ b/software/pkg-lists-wmla120_x86_64.yml
@@ -649,6 +649,7 @@ yum_pkgs_x86_64:
 # # # resolution
 - wget
 - ntp
+- nfs-utils
 cuda_drivers:
       - cuda-10-1-10.1.105-1
       - cuda-10.1.105-1

--- a/software/pkg-lists-wmla120_x86_64.yml
+++ b/software/pkg-lists-wmla120_x86_64.yml
@@ -644,6 +644,11 @@ yum_pkgs_x86_64:
 - libquadmath
 - libquadmath-devel
 - freetype
+# Do not remove the additional packages below. They are included
+# # # in the pup kickstart and are thus not detected in package dependency
+# # # resolution
+- wget
+- ntp
 cuda_drivers:
       - cuda-10-1-10.1.105-1
       - cuda-10.1.105-1


### PR DESCRIPTION
Add wget and ntp to package lists. These were not resolved by package
dependency tooling as they are included in the pup kickstart file.