### PR TITLE
Fix: parse_rpm_filenames using single package details failure

### DIFF
--- a/scripts/python/lib/utilities.py
+++ b/scripts/python/lib/utilities.py
@@ -1536,7 +1536,7 @@ def parse_rpm_filenames(filename):
                 basename.append(bn)
                 version.append(ver)
     elif isinstance(filename, str):
-        res = re.searc(pattern_basename, filename)
+        res = re.search(pattern_basename, filename)
         if res:
             basename = res.group(1)
         res = re.search(pattern_version, filename)


### PR DESCRIPTION
Refracting a typo to use re.search module