### PR TITLE
fix: Specify PyYaml Loader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ npyscreen==4.10.5
 orderedattrdict==1.5
 paramiko==2.4.2
 pip2pi==0.7.0
-pyaml==17.12.1
+pyaml==18.11.0
 pyasn1==0.4.4
 pycryptodome==3.7.0
 pyghmi==1.2.14
@@ -20,4 +20,4 @@ pyroute2==0.5.3
 pysnmp==4.4.6
 tabulate==0.8.2
 wget==3.2
-PyYAML==3.13 # do not change this
+PyYAML==5.1

--- a/scripts/python/format_yaml.py
+++ b/scripts/python/format_yaml.py
@@ -39,7 +39,7 @@ YAML_IN_FILE = abs_path(sys.argv[1])
 YAML_OUT_FILE = abs_path(sys.argv[2])
 
 try:
-    CONTENT = yaml.load(open(YAML_IN_FILE), Loader=AttrDictYAMLLoader)
+    CONTENT = yaml.full_load(open(YAML_IN_FILE), Loader=AttrDictYAMLLoader)
 except:
     print('Could not load file: ' + YAML_IN_FILE)
     sys.exit(1)

--- a/scripts/python/lib/db.py
+++ b/scripts/python/lib/db.py
@@ -64,7 +64,7 @@ class DatabaseConfig(object):
 
         msg = "Failed to load '{}'".format(yaml_file)
         try:
-            return yaml.load(open(yaml_file), Loader=AttrDictYAMLLoader)
+            return yaml.full_load(open(yaml_file), Loader=AttrDictYAMLLoader)
         except yaml.parser.ParserError as exc:
             self.log.error("Failed to parse JSON '{}' - {}".format(
                 yaml_file, exc))
@@ -146,7 +146,7 @@ class DatabaseInventory(object):
 
         msg = "Failed to load '{}'".format(yaml_file)
         try:
-            return yaml.load(open(yaml_file), Loader=AttrDictYAMLLoader)
+            return yaml.full_load(open(yaml_file), Loader=AttrDictYAMLLoader)
         except yaml.parser.ParserError as exc:
             self.log.error("Failed to parse JSON '{}' - {}".format(
                 yaml_file, exc))

--- a/scripts/python/lib/genesis.py
+++ b/scripts/python/lib/genesis.py
@@ -313,7 +313,8 @@ def get_os_image_urls_yaml_path():
 
 def get_os_image_urls():
     os_image_urls_yaml_path = get_os_image_urls_yaml_path()
-    os_image_urls = yaml.load(open(os_image_urls_yaml_path))['os_image_urls']
+    os_image_urls = (
+        yaml.full_load(open(os_image_urls_yaml_path))['os_image_urls'])
     return os_image_urls
 
 

--- a/scripts/python/lib/ipmi.py
+++ b/scripts/python/lib/ipmi.py
@@ -109,7 +109,7 @@ def ipmi_fru2dict(fru_str):
                 line = split[0] + ': "' + split[1] + '"'
                 yaml_data.append(line)
     yaml_data = '\n'.join(yaml_data)
-    return yaml.load(yaml_data)
+    return yaml.full_load(yaml_data)
 
 
 def extract_system_sn_pn(ipmi_fru_str):

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -204,7 +204,7 @@ def pxelinux_configuration(profile_object, kernel, initrd, kickstart):
 def initiate_pxeboot(profile_object, node_list_file):
     log = logger.getlogger()
     p_node = profile_object.get_node_profile_tuple()
-    node_list = yaml.load(open(node_list_file))
+    node_list = yaml.full_load(open(node_list_file))
     for node in node_list:
         ip = node['bmc_ip']
         userid = p_node.bmc_userid
@@ -224,7 +224,7 @@ def initiate_pxeboot(profile_object, node_list_file):
 def reset_bootdev(profile_object, node_list_file):
     log = logger.getlogger()
     p_node = profile_object.get_node_profile_tuple()
-    node_list = yaml.load(open(node_list_file))
+    node_list = yaml.full_load(open(node_list_file))
     for node in node_list:
         ip = node['bmc_ip']
         userid = p_node.bmc_userid

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -243,7 +243,7 @@ def update_install_status(node_dict_file, start_time, write_results=True):
     """
     log = logger.getlogger()
     status_dir = CLIENT_STATUS_DIR
-    nodes = yaml.load(open(node_dict_file))
+    nodes = yaml.full_load(open(node_dict_file))
 
     def _associate_pxe_to_bmc(nodes, pxe_ip, report_data=None):
         for bmc_mac, value in nodes['selected'].items():
@@ -337,7 +337,7 @@ def get_install_status(node_dict_file, colorized=False):
     Returns:
         str: Installation status table
     """
-    nodes = yaml.load(open(node_dict_file))
+    nodes = yaml.full_load(open(node_dict_file))
 
     def _try_dict_key(dictionary, *keys):
         value = dictionary
@@ -456,8 +456,8 @@ class Profile():
                 self.prof_path = os.path.join(GEN_SAMPLE_CONFIGS_PATH,
                                               'profile-template.yml')
         try:
-            self.profile = yaml.load(open(self.prof_path),
-                                     Loader=AttrDictYAMLLoader)
+            self.profile = yaml.full_load(open(self.prof_path),
+                                          Loader=AttrDictYAMLLoader)
         except IOError:
             self.log.error('Unable to open the profile file: '
                            f'{self.prof_path}')

--- a/scripts/python/str2dict.py
+++ b/scripts/python/str2dict.py
@@ -62,7 +62,7 @@ def ipmi_fru2dict(fru_str):
                 line = split[0] + ': "' + split[1] + '"'
                 yaml_data.append(line)
     yaml_data = '\n'.join(yaml_data)
-    return yaml.load(yaml_data)
+    return yaml.full_load(yaml_data)
 
 
 def _get_system_sn_pn(ipmi_fru_str):

--- a/scripts/python/switch_cfg.py
+++ b/scripts/python/switch_cfg.py
@@ -71,14 +71,14 @@ def main(_class, host):
     log = logger.getlogger()
     cfg_file_path = GEN_PATH + 'scripts/python/switch-cfg-{}.yml'
     try:
-        cfg = yaml.load(open(cfg_file_path.format(_class)))
+        cfg = yaml.full_load(open(cfg_file_path.format(_class)))
     except:
         print('Could not load file: ' + cfg_file_path.format(_class))
         print('Copying from template file')
         try:
             copyfile(GEN_PATH + 'scripts/python/switch-cfg-template.yml',
                      cfg_file_path.format(_class))
-            cfg = yaml.load(open(cfg_file_path.format(_class)))
+            cfg = yaml.full_load(open(cfg_file_path.format(_class)))
         except:
             print('Could not load file: ' + cfg_file_path.format(_class))
             sys.exit(1)

--- a/software/get-dependent-packages.sh
+++ b/software/get-dependent-packages.sh
@@ -48,7 +48,7 @@ fi
 
 pkglist=$(python -c \
 "import yaml;\
-pkgs = yaml.load(open('$pkglistfile'));\
+pkgs = yaml.full_load(open('$pkglistfile'));\
 print(' '.join(pkgs['yum_pkgs_$3']))")
 
 if [[ "$3" == "p8" ]]; then
@@ -56,7 +56,7 @@ versionless_pkglist=$(python - << "EOF"
 import yaml
 import re
 pattern_basename = r'([-_+\w.]+)(?=-(\d+[:.]\d+){1,3}).+'
-pkgs = yaml.load(open('pkg-lists-wmla120.yml'))
+pkgs = yaml.full_load(open('pkg-lists-wmla120.yml'))
 pkg_list = pkgs['yum_pkgs_p8']
 pkg_basename = []
 for pkg_name in pkg_list:
@@ -72,7 +72,7 @@ versionless_pkglist=$(python - << "EOF"
 import yaml
 import re
 pattern_basename = r'([-_+\w.]+)(?=-(\d+[:.]\d+){1,3}).+'
-pkgs = yaml.load(open('pkg-lists-wmla120.yml'))
+pkgs = yaml.full_load(open('pkg-lists-wmla120.yml'))
 pkg_list = pkgs['yum_pkgs_p9']
 pkg_basename = []
 for pkg_name in pkg_list:
@@ -88,7 +88,7 @@ versionless_pkglist=$(python - << "EOF"
 import yaml
 import re
 pattern_basename = r'([-_+\w.]+)(?=-(\d+[:.]\d+){1,3}).+'
-pkgs = yaml.load(open('pkg-lists-wmla120_x86_64.yml'))
+pkgs = yaml.full_load(open('pkg-lists-wmla120_x86_64.yml'))
 pkg_list = pkgs['yum_pkgs_x86_64']
 pkg_basename = []
 for pkg_name in pkg_list:

--- a/software/paie111.py
+++ b/software/paie111.py
@@ -83,19 +83,22 @@ class software(object):
                         'Python Package Repository': 'pypi'}
 
         try:
-            self.pkgs = yaml.load(open(GEN_SOFTWARE_PATH + 'pkg-lists111.yml'))
+            self.pkgs = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                            'pkg-lists111.yml'))
         except IOError:
             self.log.error('Error opening the pkg lists file (pkg-lists111.yml)')
             sys.exit('Exit due to critical error')
 
         if self.eval_ver:
             try:
-                self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
+                self.sw_vars = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                                   'software-vars-eval.yml'))
             except IOError:
                 # if no eval vars file exist, see if the license var file exists
                 # and start with that
                 try:
-                    self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars.yml'))
+                    self.sw_vars = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                                       'software-vars.yml'))
                 except IOError:
                     self.log.info('Creating software vars yaml file')
                     self.sw_vars = {}
@@ -112,12 +115,14 @@ class software(object):
                     self.sw_vars['prep-timestamp'] = calendar.timegm(time.gmtime())
         else:
             try:
-                self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars.yml'))
+                self.sw_vars = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                                   'software-vars.yml'))
             except IOError:
                 # if no licensed vars file exist, see if the eval var file exists
                 # and start with that
                 try:
-                    self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
+                    self.sw_vars = yaml.full_load(
+                        open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
                 except IOError:
                     self.log.info('Creating software vars yaml file')
                     self.sw_vars = {}
@@ -143,14 +148,16 @@ class software(object):
         if self.eval_ver:
             self.eval_prep_timestamp = self.sw_vars['prep-timestamp']
             try:
-                temp = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars.yml'))
+                temp = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                           'software-vars.yml'))
                 self.lic_prep_timestamp = temp['prep-timestamp']
             except (IOError, KeyError):
                 self.lic_prep_timestamp = 0
         else:
             self.lic_prep_timestamp = self.sw_vars['prep-timestamp']
             try:
-                temp = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
+                temp = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                           'software-vars-eval.yml'))
                 self.eval_prep_timestamp = temp['prep-timestamp']
             except (IOError, KeyError):
                 self.eval_prep_timestamp = 0
@@ -179,7 +186,8 @@ class software(object):
         # regular extression of [0-9]{0,3} Other asterisks are converted to regular
         # expression of .*
         try:
-            file_lists = yaml.load(open(GEN_SOFTWARE_PATH + 'file-lists111.yml'))
+            file_lists = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                             'file-lists111.yml'))
         except IOError:
             self.log.info('Error while reading installation file lists for PowerAI Enterprise')
             sys.exit('exiting')
@@ -1338,8 +1346,8 @@ class software(object):
         _set_spectrum_conductor_install_env(self.sw_vars['ansible_inventory'],
                                             'dli')
 
-        install_tasks = yaml.load(open(GEN_SOFTWARE_PATH +
-                                       'paie111_install_procedure.yml'))
+        install_tasks = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                            'paie111_install_procedure.yml'))
         for task in install_tasks:
             heading1(f"Client Node Action: {task['description']}")
             if task['description'] == "Install Anaconda installer":
@@ -1536,7 +1544,7 @@ def _set_spectrum_conductor_install_env(ansible_inventory, package):
     init = True
     while not env_validated:
         try:
-            for key, value in yaml.load(open(envs_path)).items():
+            for key, value in yaml.full_load(open(envs_path)).items():
                 if value is None:
                     break
             else:

--- a/software/paie112.py
+++ b/software/paie112.py
@@ -86,19 +86,22 @@ class software(object):
                         'Python Package Repository': 'pypi'}
 
         try:
-            self.pkgs = yaml.load(open(GEN_SOFTWARE_PATH + 'pkg-lists112.yml'))
+            self.pkgs = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                            'pkg-lists112.yml'))
         except IOError:
             self.log.error('Error opening the pkg lists file (pkg-lists112.yml)')
             sys.exit('Exit due to critical error')
 
         if self.eval_ver:
             try:
-                self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
+                self.sw_vars = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                                   'software-vars-eval.yml'))
             except IOError:
                 # if no eval vars file exist, see if the license var file exists
                 # and start with that
                 try:
-                    self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars.yml'))
+                    self.sw_vars = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                                       'software-vars.yml'))
                 except IOError:
                     self.log.info('Creating software vars yaml file')
                     self.sw_vars = {}
@@ -115,12 +118,14 @@ class software(object):
                     self.sw_vars['prep-timestamp'] = calendar.timegm(time.gmtime())
         else:
             try:
-                self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars.yml'))
+                self.sw_vars = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                                   'software-vars.yml'))
             except IOError:
                 # if no licensed vars file exist, see if the eval var file exists
                 # and start with that
                 try:
-                    self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
+                    self.sw_vars = yaml.full_load(
+                        open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
                 except IOError:
                     self.log.info('Creating software vars yaml file')
                     self.sw_vars = {}
@@ -146,14 +151,16 @@ class software(object):
         if self.eval_ver:
             self.eval_prep_timestamp = self.sw_vars['prep-timestamp']
             try:
-                temp = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars.yml'))
+                temp = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                           'software-vars.yml'))
                 self.lic_prep_timestamp = temp['prep-timestamp']
             except (IOError, KeyError):
                 self.lic_prep_timestamp = 0
         else:
             self.lic_prep_timestamp = self.sw_vars['prep-timestamp']
             try:
-                temp = yaml.load(open(GEN_SOFTWARE_PATH + 'software-vars-eval.yml'))
+                temp = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                           'software-vars-eval.yml'))
                 self.eval_prep_timestamp = temp['prep-timestamp']
             except (IOError, KeyError):
                 self.eval_prep_timestamp = 0
@@ -182,7 +189,8 @@ class software(object):
         # regular extression of [0-9]{0,3} Other asterisks are converted to regular
         # expression of .*
         try:
-            file_lists = yaml.load(open(GEN_SOFTWARE_PATH + 'file-lists112.yml'))
+            file_lists = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                             'file-lists112.yml'))
         except IOError:
             self.log.info('Error while reading installation file lists for PowerAI Enterprise')
             sys.exit('exiting')
@@ -1380,8 +1388,8 @@ class software(object):
         _set_spectrum_conductor_install_env(self.sw_vars['ansible_inventory'],
                                             'dli', ana_ver)
 
-        install_tasks = yaml.load(open(GEN_SOFTWARE_PATH +
-                                       f'{self.my_name}_install_procedure.yml'))
+        install_tasks = yaml.full_load(
+            open(GEN_SOFTWARE_PATH + f'{self.my_name}_install_procedure.yml'))
         for task in install_tasks:
             heading1(f"Client Node Action: {task['description']}")
             if task['description'] == "Install Anaconda installer":
@@ -1579,7 +1587,7 @@ def _set_spectrum_conductor_install_env(ansible_inventory, package, ana_ver=None
     init = True
     while not env_validated:
         try:
-            for key, value in yaml.load(open(envs_path)).items():
+            for key, value in yaml.full_load(open(envs_path)).items():
                 if value is None:
                     break
             else:

--- a/software/wmla120.py
+++ b/software/wmla120.py
@@ -90,14 +90,14 @@ class software(object):
         self._load_pkglist()
 
         try:
-            self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH +
-                                     f'{self.sw_vars_file_name}'))
+            self.sw_vars = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                               f'{self.sw_vars_file_name}'))
         except IOError:
             # if no eval vars file exist, see if the license var file exists
             # and start with that
             try:
-                self.sw_vars = yaml.load(open(GEN_SOFTWARE_PATH +
-                                         f'{self.sw_vars_file_name}'))
+                self.sw_vars = yaml.full_load(
+                    open(GEN_SOFTWARE_PATH + f'{self.sw_vars_file_name}'))
             except IOError:
                 self.log.info('Creating software vars yaml file')
                 self.sw_vars = {}
@@ -123,14 +123,16 @@ class software(object):
         if self.eval_ver:
             self.eval_prep_timestamp = self.sw_vars['prep-timestamp']
             try:
-                temp = yaml.load(open(GEN_SOFTWARE_PATH + f'{self.sw_vars_file_name}'))
+                temp = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                           f'{self.sw_vars_file_name}'))
                 self.lic_prep_timestamp = temp['prep-timestamp']
             except (IOError, KeyError):
                 self.lic_prep_timestamp = 0
         else:
             self.lic_prep_timestamp = self.sw_vars['prep-timestamp']
             try:
-                temp = yaml.load(open(GEN_SOFTWARE_PATH + f'{self.sw_vars_file_name}'))
+                temp = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                           f'{self.sw_vars_file_name}'))
                 self.eval_prep_timestamp = temp['prep-timestamp']
             except (IOError, KeyError):
                 self.eval_prep_timestamp = 0
@@ -1373,7 +1375,9 @@ class software(object):
 
     def _load_pkglist(self):
         try:
-            self.pkgs = yaml.load(open(GEN_SOFTWARE_PATH + f'pkg-lists-{self.base_filename}.yml'))
+            self.pkgs = yaml.full_load(
+                open(GEN_SOFTWARE_PATH +
+                     f'pkg-lists-{self.base_filename}.yml'))
         except IOError:
             self.log.error(f'Error opening the pkg lists file '
                            f'(pkg-lists-{self.base_filename}.yml)')
@@ -1385,7 +1389,9 @@ class software(object):
         # regular extression of [0-9]{0,3} Other asterisks are converted to regular
         # expression of .*
         try:
-            file_lists = yaml.load(open(GEN_SOFTWARE_PATH + f'file-lists-{self.base_filename}.yml'))
+            file_lists = yaml.full_load(
+                open(GEN_SOFTWARE_PATH +
+                     f'file-lists-{self.base_filename}.yml'))
         except IOError:
             self.log.info('Error while reading installation file lists for WMLA Enterprise')
             sys.exit('exiting')
@@ -1620,8 +1626,9 @@ class software(object):
         _set_spectrum_conductor_install_env(self.sw_vars['ansible_inventory'],
                                             'dli', ana_ver)
         specific_arch = "_" + self.arch if self.arch == 'x86_64' else ""
-        install_tasks = yaml.load(open(GEN_SOFTWARE_PATH +
-                                       f'{self.my_name}_install_procedure{specific_arch}.yml'))
+        install_tasks = yaml.full_load(
+            open(GEN_SOFTWARE_PATH +
+                 f'{self.my_name}_install_procedure{specific_arch}.yml'))
 
         for task in install_tasks:
             if 'engr_mode' in task['tasks'] and not self.eng_mode:
@@ -1835,7 +1842,7 @@ def _set_spectrum_conductor_install_env(ansible_inventory, package, ana_ver=None
     init = True
     while not env_validated:
         try:
-            for key, value in yaml.load(open(envs_path)).items():
+            for key, value in yaml.full_load(open(envs_path)).items():
                 if value is None:
                     break
             else:

--- a/software/wmla120.py
+++ b/software/wmla120.py
@@ -70,7 +70,8 @@ class software(object):
         if self.arch == 'x86_64' and not proc_family:
             self.proc_family = self.arch
         self.eng_mode = engr_mode
-        yaml.add_constructor(YAMLVault.yaml_tag, YAMLVault.from_yaml)
+        yaml.FullLoader.add_constructor(YAMLVault.yaml_tag,
+                                        YAMLVault.from_yaml)
         self.ana_platform_basename = '64' if self.arch == "x86_64" else self.arch
         self.sw_vars_file_name = 'software-vars'
         self.sw_vars_file_name = self.sw_vars_file_name + '-eval' if self.eval_ver \

--- a/software/wmla120.py
+++ b/software/wmla120.py
@@ -1404,9 +1404,9 @@ class software(object):
 
     def _load_content(self):
         try:
-            self.content = yaml.load(open(GEN_SOFTWARE_PATH +
-                                     f'content-{self.my_name}.yml'),
-                                     Loader=AttrDictYAMLLoader)
+            self.content = yaml.full_load(open(GEN_SOFTWARE_PATH +
+                                          f'content-{self.my_name}.yml'),
+                                          Loader=AttrDictYAMLLoader)
         except IOError:
             self.log.error(f'Error opening the content list file '
                            f'(content-{self.base_filename}.yml)')


### PR DESCRIPTION
Python module 'PyYaml' version '4.2b1' and earlier used a default loader
that allowed arbitrary code execution. Updating the 'PyYaml'  module to
version '5.1' and always specifying the Loader (using shortcut "sugar"
method 'yaml.full_load') allows for "safe" loading without deprecation
warnings.