### PR TITLE
fix: Update Ansible module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.1
+ansible==2.7.10
 ansible-vault==1.2.0
 click==7.0
 cryptography==2.4.2


### PR DESCRIPTION
Ansible '2.7.1' fetch module is exposed to a security vulnerability that
is fixed in >= '2.7.8'. (https://nvd.nist.gov/vuln/detail/CVE-2019-3828)