### PR TITLE
fix: address ansible-lint fail by removing all procedure files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 envlist = py36,bashate,flake8,ansible-lint,\
           commit-message-validate,verify-copyright,\
           file-format
-          
+
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
@@ -69,7 +69,7 @@ basepython = python3.6
 commands =
     # Perform an Ansible lint check
     bash -c \"find {toxinidir} \
-    -name '*_install_procedure*.yml' -prune -o \
+    -name '*_procedure*.yml' -prune -o \
     -name '*.tox*' -prune -o \
     -name '*.yml' -print -o \
     -name '*.yaml' -print -o \


### PR DESCRIPTION
when running ansible-lint with *_install_procedure*.yml, causing it to fail due new validation procedure, this now covers all procedures.