### PR TITLE
fix: Set root_dir selinux file type on move

### DIFF
--- a/scripts/python/create_base_dir_wmla120.py
+++ b/scripts/python/create_base_dir_wmla120.py
@@ -64,7 +64,12 @@ def create_base_dir(base_dir):
             print(f'Found dir: {path}')
             if action == 'move':
                 try:
-                    move(path, f'{base_dir}/wmla120-{arch}/')
+                    _dir = f'{base_dir}/wmla120-{arch}/'
+                    move(path, _dir)
+                    cmd = f'sudo chcon -Rv --type=httpd_sys_content_t {_dir}'
+                    _, err, rc = sub_proc_exec(cmd)
+                    if rc != 0:
+                        log.error(f'chtype of directory {_dir} failed {err}')
                 except shutil_Error as exc:
                     print(exc)
             elif action == 'copy':

--- a/scripts/python/gen.py
+++ b/scripts/python/gen.py
@@ -799,10 +799,9 @@ class Gen(object):
                         for task in self.args.run_ansible_task:
                             task_file = soft.get_software_path(os.path.basename(task))
                             if not os.path.isfile(task_file):
-                                print('\nUnable to find: ' + task_file )
+                                print('\nUnable to find: ' + task_file)
                             else:
-                                run_it_file = run_it_file + '''\n- description: Running file {0}\n  tasks: {1}\n'''.format(soft.get_software_path(os.path.basename(task_file)),
-                                                                                os.path.basename(task_file))
+                                run_it_file = run_it_file + '''\n- description: Running file {0}\n  tasks: {1}\n'''.format(soft.get_software_path(os.path.basename(task_file)), os.path.basename(task_file))
                         if hasattr(soft, run_this) and run_it_file != "":
                             func = getattr(soft, run_this)
                             fileobj = tempfile.NamedTemporaryFile()

--- a/software/wmla120.py
+++ b/software/wmla120.py
@@ -334,7 +334,7 @@ class software(object):
             if item == 'Firewall':
                 cmd = 'firewall-cmd --list-all'
                 resp, _, _ = sub_proc_exec(cmd)
-                if not '(active)' in resp:
+                if '(active)' not in resp:
                     self.state[item] = "Firewall is not running"
                 elif re.search(r'services:\s+.+http', resp):
                     self.state[item] = "Running and configured for http"


### PR DESCRIPTION
Set root_dir selinux file type on move of root directory to new
root_dir directory structure.
Clear some minor tox issues.