### PR TITLE
fix: Decrement BMC credential count

### DIFF
--- a/scripts/python/validate_cluster_hardware.py
+++ b/scripts/python/validate_cluster_hardware.py
@@ -316,8 +316,11 @@ class ValidateClusterHardware(object):
                             self.log.debug(f'No power status response from node {node}')
             time.sleep(delay)
         if left != 0:
-            self.log.error(f'IPMI communication successful with only {tot - left} '
-                           f'of {tot} nodes')
+            self.log.error('IPMI communication successful with only '
+                           f'{tot - left} of {tot} nodes')
+            raise UserException('Unable to validate the following IPMI IP '
+                                'Addresses :'
+                                f'{[x for x in nodes if not nodes[x]]}')
         print('\n')
         return bmc_ai
 

--- a/scripts/python/validate_cluster_hardware.py
+++ b/scripts/python/validate_cluster_hardware.py
@@ -307,7 +307,7 @@ class ValidateClusterHardware(object):
                             self.log.debug(f'Node {node} is powered {r}')
                             bmc_ai[node] = tuple(cred_list[j][:-1])
                             cred_list[j][3] -= 1
-                            left -= left
+                            left -= 1
                             print(f'\r{tot - left} of {tot} nodes communicating via IPMI',
                                   end='')
                             sys.stdout.flush()


### PR DESCRIPTION
When validating BMC IPMI/OpenBMC credentials a count is stored to keep
track of the successful connections. When a new successful connection is
validated the count is decremented by the _total_ number of BMCs instead
of 1. This resulted in a binary pass/fail if _any_ or _no_ BMC
connections were validated.