### PR TITLE
fix: Add gather facts set to false to validate_bootstrap_vars.yml

### DIFF
--- a/playbooks/validate_bootstrap_vars.yml
+++ b/playbooks/validate_bootstrap_vars.yml
@@ -17,6 +17,7 @@
 
 - name: Software bootstrap validation
   hosts: localhost
+  gather_facts: False
   tasks:
     - name: Validate software bootstrap parsing
       debug:


### PR DESCRIPTION
When any pup module is called that utilizes validate_bootstrap_vars.yml ,
the system hangs and fails to progress i.e.  pup validate --config-file.
When fact gathering is set to false, the deployer is able to
proceed with WMLA setup.