### PR TITLE
fix: Change mount point template to avoid using rhel76 user

### DIFF
--- a/software/wmla120_ansible/env_vars/setup_private_env_vars.yml
+++ b/software/wmla120_ansible/env_vars/setup_private_env_vars.yml
@@ -40,9 +40,9 @@ file_points:
     group: nfsnobody
     mode: "u=rwx,g=rx,o=rx"
     state: directory
-  - path: "{{ install_mount_dir }}/jja"
-    owner: rhel76 
-    group: rhel76
+  - path: "{{ install_mount_dir }}/dli_shared_fs"
+    owner: nfsnobody 
+    group: nfsnobody
     mode: "u=rwx,g=rx,o=rx"
     state: directory
     recurse: yes


### PR DESCRIPTION
Using rhel76 user in mount point template will lead to failures
when the template is used unedited. If we use existing user
like nfsnobody such issues can be avoided.

Signed-off-by: Kothapally Madhu Pavan <makothap@in.ibm.com>