### PR TITLE
fix: Do not call 'yaml.full_load()' with 'Loader='

### DIFF
--- a/scripts/python/format_yaml.py
+++ b/scripts/python/format_yaml.py
@@ -39,7 +39,7 @@ YAML_IN_FILE = abs_path(sys.argv[1])
 YAML_OUT_FILE = abs_path(sys.argv[2])
 
 try:
-    CONTENT = yaml.full_load(open(YAML_IN_FILE), Loader=AttrDictYAMLLoader)
+    CONTENT = yaml.load(open(YAML_IN_FILE), Loader=AttrDictYAMLLoader)
 except:
     print('Could not load file: ' + YAML_IN_FILE)
     sys.exit(1)

--- a/scripts/python/lib/db.py
+++ b/scripts/python/lib/db.py
@@ -64,7 +64,7 @@ class DatabaseConfig(object):
 
         msg = "Failed to load '{}'".format(yaml_file)
         try:
-            return yaml.full_load(open(yaml_file), Loader=AttrDictYAMLLoader)
+            return yaml.load(open(yaml_file), Loader=AttrDictYAMLLoader)
         except yaml.parser.ParserError as exc:
             self.log.error("Failed to parse JSON '{}' - {}".format(
                 yaml_file, exc))
@@ -146,7 +146,7 @@ class DatabaseInventory(object):
 
         msg = "Failed to load '{}'".format(yaml_file)
         try:
-            return yaml.full_load(open(yaml_file), Loader=AttrDictYAMLLoader)
+            return yaml.load(open(yaml_file), Loader=AttrDictYAMLLoader)
         except yaml.parser.ParserError as exc:
             self.log.error("Failed to parse JSON '{}' - {}".format(
                 yaml_file, exc))

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -456,8 +456,8 @@ class Profile():
                 self.prof_path = os.path.join(GEN_SAMPLE_CONFIGS_PATH,
                                               'profile-template.yml')
         try:
-            self.profile = yaml.full_load(open(self.prof_path),
-                                          Loader=AttrDictYAMLLoader)
+            self.profile = yaml.load(open(self.prof_path),
+                                     Loader=AttrDictYAMLLoader)
         except IOError:
             self.log.error('Unable to open the profile file: '
                            f'{self.prof_path}')

--- a/software/wmla120.py
+++ b/software/wmla120.py
@@ -1404,9 +1404,9 @@ class software(object):
 
     def _load_content(self):
         try:
-            self.content = yaml.full_load(open(GEN_SOFTWARE_PATH +
-                                          f'content-{self.my_name}.yml'),
-                                          Loader=AttrDictYAMLLoader)
+            self.content = yaml.load(open(GEN_SOFTWARE_PATH +
+                                     f'content-{self.my_name}.yml'),
+                                     Loader=AttrDictYAMLLoader)
         except IOError:
             self.log.error(f'Error opening the content list file '
                            f'(content-{self.base_filename}.yml)')


### PR DESCRIPTION
The 'yaml.full_load()' function is a shortcut to call
'yaml.load(input, Loader=yaml.FullLoader)'. When specifying a Loader (in
this case 'Loader=AttrDictYAMLLoader') the 'yaml.load()' function should
be called.