### PR TITLE
refactor: Use BMC control modules in osinstall

### DIFF
--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -877,9 +877,6 @@ class Pup_form(npyscreen.ActionFormV2):
                 self.fields[item].entry_widget.add_handlers({curses.KEY_F1:
                                                              self.h_help})
 
-        if hasattr(self.form, 'status_table'):
-            self.update_status_values()
-
     def on_cancel(self):
         fvl = self.parentApp._FORM_VISIT_LIST
         res = npyscreen.notify_yes_no('Quit without saving?',

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -209,14 +209,15 @@ def pxelinux_configuration(profile_object, kernel, initrd, kickstart):
         kopts=kopts)
 
 
-def get_selected_clients(profile_object, node_dict_file):
+def get_selected_clients(profile_object, node_dict_file, bmc_ip='all'):
     p_node = profile_object.get_node_profile_tuple()
     nodes = yaml.full_load(open(node_dict_file))
     clients = {}
     for node in nodes['selected'].values():
-        clients[node['bmc_ip']] = (p_node.bmc_userid,
-                                   p_node.bmc_password,
-                                   'ipmi')  # TODO: Query type
+        if bmc_ip == 'all' or bmc_ip == node['bmc_ip']:
+            clients[node['bmc_ip']] = (p_node.bmc_userid,
+                                       p_node.bmc_password,
+                                       'ipmi')  # TODO: Query type
     return clients
 
 
@@ -424,7 +425,9 @@ def get_install_status(node_dict_file, colorized=False):
 
 
 def reset_bootdev(profile_object, node_dict_file, bmc_ip='all'):
-    clients = get_selected_clients(profile_object, node_dict_file)
+    clients = get_selected_clients(profile_object,
+                                   node_dict_file,
+                                   bmc_ip=bmc_ip)
     set_bootdev_clients('disk', persist=False, clients=clients)
 
 


### PR DESCRIPTION
The 'set_*_client' modules to issue commands to BMCs include hardening
controls that can benefit osinstall.