### PR TITLE
fix: Return 'disk' from ipmi.hostBootSource

### DIFF
--- a/scripts/python/lib/ipmi.py
+++ b/scripts/python/lib/ipmi.py
@@ -302,6 +302,8 @@ def hostBootSource(host, source, bmc, timeout=None):
             res = None
         else:
             res = res['bootdev']
+            if res == 'hd':
+                res = 'disk'
     else:
         try:
             res = bmc.get_bootdev()
@@ -311,6 +313,8 @@ def hostBootSource(host, source, bmc, timeout=None):
             res = None
         else:
             res = res['bootdev']
+            if res == 'hd':
+                res = 'disk'
     return res
 
 

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -40,6 +40,9 @@ import lib.utilities as u
 from nginx_setup import nginx_setup
 from ip_route_get_to import ip_route_get_to
 from lib.bmc import Bmc
+from set_bootdev_clients import set_bootdev_clients
+from set_power_clients import set_power_clients
+from lib.genesis import get_power_wait
 
 GEN_PATH = get_package_path()
 GEN_SAMPLE_CONFIGS_PATH = get_sample_configs_path()
@@ -52,6 +55,8 @@ NODE_STATUS = os.path.join(GEN_PATH, 'osinstall_node_status.yml')
 HTTP_ROOT_DIR = get_nginx_root_dir()
 OSINSTALL_HTTP_DIR = 'osinstall'
 CLIENT_STATUS_DIR = '/var/pup_install_status/'
+
+POWER_WAIT = get_power_wait()
 
 
 def osinstall(profile_path):
@@ -225,24 +230,23 @@ def pxelinux_configuration(profile_object, kernel, initrd, kickstart):
         kopts=kopts)
 
 
-def initiate_pxeboot(profile_object, node_dict_file):
-    log = logger.getlogger()
+def get_selected_clients(profile_object, node_dict_file, bmc_ip='all'):
     p_node = profile_object.get_node_profile_tuple()
     nodes = yaml.full_load(open(node_dict_file))
+    clients = {}
     for node in nodes['selected'].values():
-        ip = node['bmc_ip']
-        userid = p_node.bmc_userid
-        passwd = p_node.bmc_password
-        bmc = Bmc(ip, userid, passwd)
-        if bmc.is_connected():
-            log.debug(f"Successfully connected to BMC: host={ip} "
-                      f"userid={userid} password={passwd}")
-            bmc.chassis_power('off')
-            bmc.host_boot_source(source='network')
-            bmc.chassis_power('on')
-        else:
-            log.error(f"Unable to connect to BMC: host={ip} "
-                      f"userid={userid} password={passwd}")
+        if bmc_ip == 'all' or bmc_ip == node['bmc_ip']:
+            clients[node['bmc_ip']] = (p_node.bmc_userid,
+                                       p_node.bmc_password,
+                                       'ipmi')  # TODO: Query type
+    return clients
+
+
+def initiate_pxeboot(profile_object, node_dict_file):
+    clients = get_selected_clients(profile_object, node_dict_file)
+    set_power_clients('off', clients=clients, wait=POWER_WAIT)
+    set_bootdev_clients('network', persist=False, clients=clients)
+    set_power_clients('on', clients=clients, wait=POWER_WAIT)
 
 
 def update_install_status(node_dict_file, start_time, write_results=True):
@@ -442,22 +446,10 @@ def get_install_status(node_dict_file, colorized=False):
 
 
 def reset_bootdev(profile_object, node_dict_file, bmc_ip='all'):
-    log = logger.getlogger()
-    p_node = profile_object.get_node_profile_tuple()
-    nodes = yaml.full_load(open(node_dict_file))
-    for node in nodes['selected'].values():
-        ip = node['bmc_ip']
-        userid = p_node.bmc_userid
-        passwd = p_node.bmc_password
-        if bmc_ip == 'all' or bmc_ip == ip:
-            bmc = Bmc(ip, userid, passwd)
-            if bmc.is_connected():
-                log.debug(f"Successfully connected to BMC: host={ip} "
-                          f"userid={userid} password={passwd}")
-                bmc.host_boot_source(source='disk')
-            else:
-                log.error(f"Unable to connect to BMC: host={ip} "
-                          f"userid={userid} password={passwd}")
+    clients = get_selected_clients(profile_object,
+                                   node_dict_file,
+                                   bmc_ip=bmc_ip)
+    set_bootdev_clients('disk', persist=False, clients=clients)
 
 
 class Profile():
@@ -861,6 +853,10 @@ class Pup_form(npyscreen.ActionFormV2):
         self.fields = {}  # dictionary for holding field instances
         self.next_form = self.parentApp.NEXT_ACTIVE_FORM
         self.talking_nodes = {}  # Nodes we can talk to using ipmi or openBMC
+        node_status_path = os.path.join(GEN_PATH, 'osinstall_node_status.yml')
+        if os.path.isfile(node_status_path):
+            os.remove(node_status_path)
+
         if hasattr(self.form, 'bmc_userid'):
             self.scan_uid = self.form.bmc_userid.val
             self.scan_pw = self.form.bmc_password.val

--- a/scripts/python/set_bootdev_clients.py
+++ b/scripts/python/set_bootdev_clients.py
@@ -26,6 +26,21 @@ import lib.bmc as _bmc
 
 def set_bootdev_clients(bootdev, persist=False, config_path=None, clients=None,
                         max_attempts=5):
+    """Set boot device for multiple clients. If a list of ip addresses
+    are given they are assumed to be PXE addresses. Corresponding BMC addresses
+    are looked up in inventory file corresponding to the config file given in
+    the config_path. Similarly if no client list is given, all BMCs enumerated in
+    the inventory file corresponding to the config file specified in config_path
+    will be acted on.  If clients is a dictionary, then the credentials are
+    taken from the dictionary values.
+
+    Args:
+        state (str) : 'on' or 'off'
+        config_path (str): path to a config file
+        clients (dict or list of str): list of IP addresses or
+        dict of ip addresses with values of credentials as tuple
+        ie {'192.168.1.2': ('user', 'password', 'bmc_type')}
+    """
     log = logger.getlogger()
     if config_path:
         inv = Inventory(cfg_file=config_path)
@@ -83,8 +98,8 @@ def set_bootdev_clients(bootdev, persist=False, config_path=None, clients=None,
     while clients_left and attempt < max_attempts:
         attempt += 1
         if attempt > 1:
-            print('Retrying set bootdev. Attempt {} of {}'.format(attempt, max_attempts))
-            print('Clients remaining: {}'.format(clients_left))
+            log.info('Retrying set bootdev. Attempt {} of {}'.format(attempt, max_attempts))
+            log.info('Clients remaining: {}'.format(clients_left))
         clients_set = []
         bmc_dict = {}
         for client in clients_left:
@@ -114,8 +129,8 @@ def set_bootdev_clients(bootdev, persist=False, config_path=None, clients=None,
 
                 if status:
                     if attempt in [2, 4, 8]:
-                        print(f'{client} - Boot source: {status} Required source: '
-                              f'{bootdev}')
+                        log.info(f'{client} - Boot source: {status} Required source: '
+                                 f'{bootdev}')
                 elif attempt == max_attempts:
                     log.error(f'Failed attempt {attempt} set boot source {bootdev} '
                               f'for node {client}')
@@ -132,7 +147,7 @@ def set_bootdev_clients(bootdev, persist=False, config_path=None, clients=None,
 
                 if status:
                     if attempt in [2, 4, 8]:
-                        print(f'{client} - Boot source: {bootdev}')
+                        log.info(f'{client} - Boot source: {bootdev}')
                     if status == bootdev:
                         log.debug(f'Successfully set boot source to {bootdev} for '
                                   f'node {client}')

--- a/scripts/python/set_power_clients.py
+++ b/scripts/python/set_power_clients.py
@@ -79,9 +79,9 @@ def set_power_clients(state, config_path=None, clients=None, max_attempts=5,
     while clients_left and attempt < max_attempts:
         attempt += 1
         if attempt > 1:
-            print('Retrying set power {}. Attempt {} of {}'
-                  .format(state, attempt, max_attempts))
-            print('Clients remaining: {}'.format(clients_left))
+            log.info('Retrying set power {}. Attempt {} of {}'
+                     .format(state, attempt, max_attempts))
+            log.info('Clients remaining: {}'.format(clients_left))
         clients_set = []
         bmc_dict = {}
         for client in clients_left:
@@ -107,7 +107,7 @@ def set_power_clients(state, config_path=None, clients=None, max_attempts=5,
                 status = bmc_dict[client].chassis_power(state, wait)
                 if status:
                     if attempt in [2, 4, 8]:
-                        print(f'{client} - Power status: {status}')
+                        log.info(f'{client} - Power status: {status}')
                     # Allow delay between turn on to limit power surge
                     if state == 'on':
                         time.sleep(0.5)
@@ -122,8 +122,8 @@ def set_power_clients(state, config_path=None, clients=None, max_attempts=5,
                 status = bmc_dict[client].chassis_power('status')
                 if status:
                     if attempt in [2, 4, 8]:
-                        print(f'{client} - Power status: {status}, '
-                              f'required state: {state}')
+                        log.info(f'{client} - Power status: {status}, '
+                                 f'required state: {state}')
                     if status == state:
                         log.debug(f'Successfully set power {state} for node {client}')
                         clients_set += [client]
@@ -145,7 +145,7 @@ def set_power_clients(state, config_path=None, clients=None, max_attempts=5,
                      len(cred_list)))
 
     if state == 'off':
-        print('Pausing 60 sec for client power off')
+        log.info('Pausing 60 sec for client power off')
         time.sleep(60)
 
     if clients_left:


### PR DESCRIPTION
Replace print with log.info in set_bootdev_clients and
set_power_clients to avoid printing to screen during OSinstall.

Remove osinstall_node_status.yml during create form.