### PR TITLE
fix: Update of engr-mode to utilize ansible_env paths

### DIFF
--- a/software/wmla120_ansible/engr_mode_client_pre_install_gather.yml
+++ b/software/wmla120_ansible/engr_mode_client_pre_install_gather.yml
@@ -4,6 +4,15 @@
     yum_pre: client_yum_pre_install.txt
     pip_pre: client_pip_pre_install.txt
 
+- name: Gathering Facts
+  setup:
+    gather_subset:
+      -  all
+
+- name: Printing the environment Variable in Ansible
+  debug:
+    msg: "{{ ansible_env }}"
+
 - name: Set dependencies directory variable
   set_fact:
     dependencies_dir: "{{ hostvars['localhost']['deps_path_local'] }}"

--- a/software/wmla120_ansible/engr_mode_client_pre_install_gather.yml
+++ b/software/wmla120_ansible/engr_mode_client_pre_install_gather.yml
@@ -4,14 +4,17 @@
     yum_pre: client_yum_pre_install.txt
     pip_pre: client_pip_pre_install.txt
 
-- name: Gathering Facts
+- name: Gathering minimal facts
   setup:
     gather_subset:
-      -  all
+      -  '!all'
+      -  '!min'
+      -  'env'
+  register: facts
 
 - name: Printing the environment Variable in Ansible
   debug:
-    msg: "{{ ansible_env }}"
+    msg: "{{ facts }}"
 
 - name: Set dependencies directory variable
   set_fact:


### PR DESCRIPTION
When running engr-mode function, a path to localhost is needed from ansible_env.HOME.
with out proper gathring of facts, the variable is undefined. To address this issue,
the addition of fact gathering in pre_install_gather is needed.