### PR TITLE
refactor: Show 'OS Info' as global status field

### DIFF
--- a/sample-configs/profile-template.yml
+++ b/sample-configs/profile-template.yml
@@ -197,11 +197,18 @@ node:
 
 # Node installation status table
 status:
+    installation_image:
+        val: null
+        desc: OS Image
+        help: OS Installation Image File
+        ftype: tftext
+
     pxeboot_status:
         val: Enabled
         desc: PXE Boot
         help: PXE Boot OS Installation Enabled or Disabled
         ftype: tftext
+        floc: skipline
 
     start_time:
         val: null

--- a/scripts/python/osinstall.py
+++ b/scripts/python/osinstall.py
@@ -383,11 +383,10 @@ def get_install_status(node_dict_file, colorized=False):
         endc = ''
 
     table = [[f'{bold}Serial', 'BMC MAC Address', 'BMC IP Address',
-              'Host IP Address', 'OS Info', f'Install Status{endc}']]
+              'Host IP Address', f'Install Status{endc}']]
     for bmc_mac, value in nodes['selected'].items():
         color = None
         pxe_ip = _try_dict_key(value, 'pxe_ip')
-        os_pretty_name = _try_dict_key(value, 'report_data', 'PRETTY_NAME')
         if _try_dict_key(value, 'start_time') != '-':
             if _try_dict_key(value, 'finish_time') != '-':
                 color = u.Color.green
@@ -408,15 +407,13 @@ def get_install_status(node_dict_file, colorized=False):
         else:
             install_status = "-"
         table.append([value['serial'], bmc_mac, value['bmc_ip'], pxe_ip,
-                      os_pretty_name, install_status])
+                      install_status])
         if colorized and color is not None:
             table[-1][0] = color + table[-1][0]
             table[-1][-1] = table[-1][-1] + u.Color.endc
     if 'other' in nodes:
         for pxe_ip, value in nodes['other'].items():
             color = None
-            os_pretty_name = _try_dict_key(value, 'report_data', 'ID') + " "
-            os_pretty_name += _try_dict_key(value, 'report_data', 'VERSION_ID')
             if _try_dict_key(value, 'start_time') != '-':
                 if _try_dict_key(value, 'finish_time') != '-':
                     color = u.Color.green
@@ -436,8 +433,7 @@ def get_install_status(node_dict_file, colorized=False):
                                                gmtime(time() - start_time)))
             else:
                 install_status = "-"
-            table.append(['?', '?', '?', pxe_ip, os_pretty_name,
-                          install_status])
+            table.append(['?', '?', '?', pxe_ip, install_status])
             if colorized and color is not None:
                 table[-1][0] = color + table[-1][0]
                 table[-1][-1] = table[-1][-1] + u.Color.endc
@@ -1534,6 +1530,10 @@ class Pup_form(npyscreen.ActionFormV2):
         return sn_pn_list
 
     def update_status_values(self):
+        self.fields['installation_image'].value = (
+            os.path.basename(
+                self.parentApp.prof.get_node_profile_tuple().iso_image_file))
+
         if Pup_form.pxeboot_enabled:
             self.fields['pxeboot_status'].value = 'Enabled'
         else:


### PR DESCRIPTION
Pup 'osinstall' supports a single OS image per install, so the 'OS Info'
for each client will be common. To reduce width of the client status
table a global 'OS Image' field will show the basename of the
installation image selected by the user.