### PR TITLE
refactor: Use 'ansible_ssh_user' var for clients

### DIFF
--- a/software/wmla120_ansible/anaconda_install.yml
+++ b/software/wmla120_ansible/anaconda_install.yml
@@ -20,7 +20,7 @@
   register: anaconda_dir
 
 - name: Install Anaconda
-  shell: "{{ ansible_env.HOME }}/{{ file }} \
+  shell: "$HOME/{{ file }} \
           -b -p {{ install_dir }} -f"
   args:
     executable: /bin/bash

--- a/software/wmla120_ansible/anaconda_prep.yml
+++ b/software/wmla120_ansible/anaconda_prep.yml
@@ -12,8 +12,8 @@
 
 - name: Download Anaconda
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     checksum: md5:a775fb6d6c441b899ff2327bd9dadc6d
     url: "http://{{ host_ip.stdout }}/{{ file }}"

--- a/software/wmla120_ansible/anaconda_prep.yml
+++ b/software/wmla120_ansible/anaconda_prep.yml
@@ -12,9 +12,8 @@
 
 - name: Download Anaconda
   get_url:
-    owner: "{{ ansible_ssh_user }}"
-    group: "{{ ansible_ssh_user }}"
     mode: 0744
     checksum: md5:a775fb6d6c441b899ff2327bd9dadc6d
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "$HOME"
+  become: yes

--- a/software/wmla120_ansible/anaconda_prep.yml
+++ b/software/wmla120_ansible/anaconda_prep.yml
@@ -17,4 +17,4 @@
     mode: 0744
     checksum: md5:a775fb6d6c441b899ff2327bd9dadc6d
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"

--- a/software/wmla120_ansible/anaconda_prep_x86_64.yml
+++ b/software/wmla120_ansible/anaconda_prep_x86_64.yml
@@ -12,8 +12,8 @@
 
 - name: Download Anaconda
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     checksum: md5:c9af603d89656bc89680889ef1f92623.
     url: "http://{{ host_ip.stdout }}/{{ file }}"

--- a/software/wmla120_ansible/anaconda_prep_x86_64.yml
+++ b/software/wmla120_ansible/anaconda_prep_x86_64.yml
@@ -17,4 +17,4 @@
     mode: 0744
     checksum: md5:c9af603d89656bc89680889ef1f92623.
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"

--- a/software/wmla120_ansible/engr_mode_client_post_install_gather.yml
+++ b/software/wmla120_ansible/engr_mode_client_post_install_gather.yml
@@ -18,7 +18,7 @@
                         #YUYM
 - name: Check that the check if YUM post data exists
   stat:
-    path: "{{ ansible_env.HOME }}/{{ yum_post }}"
+    path: "$HOME/{{ yum_post }}"
   register: yum_post_result
 
 - name: Create YUM post data file, if data doesnt exist already on client
@@ -27,13 +27,13 @@
 
 - name: Copy YUM data back to deployer
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ yum_post }}"
+    src: "$HOME/{{ yum_post }}"
     dest: "{{ dependencies_dir }}"
 
                         #PIP
 - name: Check that the check if PIP post data exists
   stat:
-    path: "{{ ansible_env.HOME }}/{{ pip_post }}"
+    path: "$HOME/{{ pip_post }}"
   register: pip_post_result
 
 - name: Create PIP post data file, if data doesnt exist already on client
@@ -42,5 +42,5 @@
 
 - name: Copy PIP data back to deployer
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ pip_post }}"
+    src: "$HOME/{{ pip_post }}"
     dest: "{{ dependencies_dir }}"

--- a/software/wmla120_ansible/engr_mode_client_pre_install_gather.yml
+++ b/software/wmla120_ansible/engr_mode_client_pre_install_gather.yml
@@ -33,7 +33,7 @@
                         #YUM
 - name: Check if YUM pre data exists
   stat:
-    path: "{{ ansible_env.HOME }}/{{ yum_pre }}"
+    path: "$HOME/{{ yum_pre }}"
   register: yum_pre_result
 
 - name: Create YUM pre data file, if data doesnt exist already on client
@@ -42,13 +42,13 @@
 
 - name: Copy YUM data back to deployer
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ yum_pre }}"
+    src: "$HOME/{{ yum_pre }}"
     dest: "{{ dependencies_dir }}"
 
                         #PIP
 - name: Check that the check if PIP pre data exists
   stat:
-    path: "{{ ansible_env.HOME }}/{{ pip_pre }}"
+    path: "$HOME/{{ pip_pre }}"
   register: pip_pre_result
 
 - name: Create PIP pre data file, if data doesnt exist already on client
@@ -57,5 +57,5 @@
 
 - name: Copy PIP data back to deployer
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ pip_pre }}"
+    src: "$HOME/{{ pip_pre }}"
     dest: "{{ dependencies_dir }}"

--- a/software/wmla120_ansible/engr_mode_env_post_install_gather.yml
+++ b/software/wmla120_ansible/engr_mode_env_post_install_gather.yml
@@ -27,7 +27,7 @@
 
 - name: Check if dlipy3 post data exists (PIP)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy3_pip }}"
+    path: "$HOME/{{ dlipy3_pip }}"
   register: dlipy3_pip_result
 
 - name: Activate dlipy3 environment and gather post data (PIP)
@@ -39,13 +39,13 @@
 
 - name: Copy data back to deployer (PIP)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy3_pip }}"
+    src: "$HOME/{{ dlipy3_pip }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy3_pip_result.stat.exists
 
 - name: Check if dlipy3 post data exists (Conda)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy3_conda }}"
+    path: "$HOME/{{ dlipy3_conda }}"
   register: dlipy3_conda_result
 
 - name: Activate dlipy3 environment and gather post data (Conda)
@@ -57,7 +57,7 @@
 
 - name: Copy data back to deployer (Conda)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy3_conda }}"
+    src: "$HOME/{{ dlipy3_conda }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy3_conda_result.stat.exists
 
@@ -65,7 +65,7 @@
 
 - name: Check if dlipy2 post data exists (PIP)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy2_pip }}"
+    path: "$HOME/{{ dlipy2_pip }}"
   register: dlipy2_pip_result
 
 - name: Activate dlipy2 environment and gather post data (PIP)
@@ -76,13 +76,13 @@
   when: not dlipy2_pip_result.stat.exists
 - name: Copy data back to deployer (PIP)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy2_pip }}"
+    src: "$HOME/{{ dlipy2_pip }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy2_pip_result.stat.exists
 
 - name: Check if dlipy2 post data exists (Conda)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy2_conda }}"
+    path: "$HOME/{{ dlipy2_conda }}"
   register: dlipy2_conda_result
 
 - name: Activate dlipy2 environment and gather post data (Conda)
@@ -94,7 +94,7 @@
 
 - name: Copy data back to deployer (Conda)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy2_conda }}"
+    src: "$HOME/{{ dlipy2_conda }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy2_conda_result.stat.exists
 
@@ -102,7 +102,7 @@
 
 - name: Check if dlinsights post data exists (PIP)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlinsights_pip }}"
+    path: "$HOME/{{ dlinsights_pip }}"
   register: dlinsights_pip_result
 
 - name: Activate dlinsights and gather post data (PIP)
@@ -114,13 +114,13 @@
 
 - name: Copy data back to deployer (PIP)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlinsights_pip }}"
+    src: "$HOME/{{ dlinsights_pip }}"
     dest: "{{ dependencies_dir }}"
   when: not dlinsights_pip_result.stat.exists
 
 - name: Check if dlinsights post data exists (Conda)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlinsights_conda }}"
+    path: "$HOME/{{ dlinsights_conda }}"
   register: dlinsights_conda_result
 
 - name: Activate dlinsights and gather post data (Conda)
@@ -132,7 +132,7 @@
 
 - name: Copy data back to deployer (Conda)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlinsights_conda }}"
+    src: "$HOME/{{ dlinsights_conda }}"
     dest: "{{ dependencies_dir }}"
   when: not dlinsights_conda_result.stat.exists
 

--- a/software/wmla120_ansible/engr_mode_env_pre_install_gather.yml
+++ b/software/wmla120_ansible/engr_mode_env_pre_install_gather.yml
@@ -38,7 +38,7 @@
 
 - name: Check if dlipy3 pre data exists (PIP)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy3_pip }}"
+    path: "$HOME/{{ dlipy3_pip }}"
   register: dlipy3_pip_result
 
 - name: Activate dlipy3_test environment and gather pre data (PIP)
@@ -50,13 +50,13 @@
 
 - name: Copy data back to deployer (PIP)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy3_pip }}"
+    src: "$HOME/{{ dlipy3_pip }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy3_pip_result.stat.exists
 
 - name: Check if dlipy3 pre data exists (Conda)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy3_conda }}"
+    path: "$HOME/{{ dlipy3_conda }}"
   register: dlipy3_conda_result
 
 - name: Activate dlipy3_test environment and gather pre data (Conda)
@@ -68,7 +68,7 @@
 
 - name: Copy data back to deployer (Conda)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy3_conda }}"
+    src: "$HOME/{{ dlipy3_conda }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy3_conda_result.stat.exists
 
@@ -87,7 +87,7 @@
 
 - name: Check if dlipy2 pre data exists (PIP)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy2_pip }}"
+    path: "$HOME/{{ dlipy2_pip }}"
   register: dlipy2_pip_result
 
 - name: Activate dlipy2_test environment and gather pre data (PIP)
@@ -99,13 +99,13 @@
 
 - name: Copy data back to deployer (PIP)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy2_pip }}"
+    src: "$HOME/{{ dlipy2_pip }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy2_pip_result.stat.exists
 
 - name: Check if dlipy2 pre data exists (Conda)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlipy2_conda }}"
+    path: "$HOME/{{ dlipy2_conda }}"
   register: dlipy2_conda_result
 
 - name: Activate dlipy2_test environment and gather pre data (Conda)
@@ -117,7 +117,7 @@
 
 - name: Copy data back to deployer (Conda)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlipy2_conda }}"
+    src: "$HOME/{{ dlipy2_conda }}"
     dest: "{{ dependencies_dir }}"
   when: not dlipy2_conda_result.stat.exists
 
@@ -136,7 +136,7 @@
 
 - name: Check if dlinsights pre data exists (PIP)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlinsights_pip }}"
+    path: "$HOME/{{ dlinsights_pip }}"
   register: dlinsights_pip_result
 
 - name: Activate dlinsights and gather pre data (PIP)
@@ -148,13 +148,13 @@
 
 - name: Copy data back to deployer (PIP)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlinsights_pip }}"
+    src: "$HOME/{{ dlinsights_pip }}"
     dest: "{{ dependencies_dir }}"
   when: not dlinsights_pip_result.stat.exists
 
 - name: Check if dlinsights pre data exists (Conda)
   stat:
-    path: "{{ ansible_env.HOME }}/{{ dlinsights_conda }}"
+    path: "$HOME/{{ dlinsights_conda }}"
   register: dlinsights_conda_result
 
 - name: Activate dlinsights and gather pre data (Conda)
@@ -166,7 +166,7 @@
 
 - name: Copy data back to deployer (Conda)
   fetch:
-    src: "{{ ansible_env.HOME }}/{{ dlinsights_conda }}"
+    src: "$HOME/{{ dlinsights_conda }}"
     dest: "{{ dependencies_dir }}"
   when: not dlinsights_conda_result.stat.exists
 

--- a/software/wmla120_ansible/entitle_spectrum_conductor_dli.yml
+++ b/software/wmla120_ansible/entitle_spectrum_conductor_dli.yml
@@ -12,8 +12,8 @@
 
 - name: Download entitlement file
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "{{ ansible_env.HOME }}"

--- a/software/wmla120_ansible/entitle_spectrum_conductor_dli.yml
+++ b/software/wmla120_ansible/entitle_spectrum_conductor_dli.yml
@@ -16,7 +16,7 @@
     group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"
 
 - name: Get enterprise license filename from software-vars.yml
   set_fact:
@@ -24,7 +24,7 @@
 
 - name: Entitle IBM Spectrum dli
   shell: "source /opt/ibm/spectrumcomputing/profile.platform && \
-  egoconfig setentitlement {{ ansible_env.HOME }}/{{ filename }}"
+  egoconfig setentitlement $HOME/{{ filename }}"
   args:
     executable: /bin/bash
 

--- a/software/wmla120_ansible/entitle_spectrum_conductor_with_spark.yml
+++ b/software/wmla120_ansible/entitle_spectrum_conductor_with_spark.yml
@@ -12,8 +12,8 @@
 
 - name: Download entitlement file
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "{{ ansible_env.HOME }}"

--- a/software/wmla120_ansible/entitle_spectrum_conductor_with_spark.yml
+++ b/software/wmla120_ansible/entitle_spectrum_conductor_with_spark.yml
@@ -16,7 +16,7 @@
     group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"
 
 - name: Get enterprise license filename from software-vars.yml
   set_fact:
@@ -25,6 +25,6 @@
 - name: Entitle IBM Spectrum Conductor with Spark
   shell: "source /opt/ibm/spectrumcomputing/profile.platform && \
   egoconfig join {{ groups['master'][0] }} -f && \
-  egoconfig setentitlement {{ ansible_env.HOME }}/{{ filename }}"
+  egoconfig setentitlement $HOME/{{ filename }}"
   args:
     executable: /bin/bash

--- a/software/wmla120_ansible/install_spectrum_conductor_dli.yml
+++ b/software/wmla120_ansible/install_spectrum_conductor_dli.yml
@@ -16,7 +16,7 @@
     group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"
 
 - name: Include configuration environment variables
   include_vars:
@@ -49,7 +49,7 @@
     filename: "{{ content_files['spectrum-dli'].split('/')[-1] }}"
 
 - name: Install IBM Spectrum Conductor DLI
-  shell: "{{ egocomputehost }} {{ ansible_env.HOME }}/{{ filename }} --quiet"
+  shell: "{{ egocomputehost }} $HOME/{{ filename }} --quiet"
   environment: "{{ envs }}"
   args:
     executable: /bin/bash

--- a/software/wmla120_ansible/install_spectrum_conductor_dli.yml
+++ b/software/wmla120_ansible/install_spectrum_conductor_dli.yml
@@ -12,8 +12,8 @@
 
 - name: Download installer binary
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "{{ ansible_env.HOME }}"

--- a/software/wmla120_ansible/install_spectrum_conductor_dli.yml
+++ b/software/wmla120_ansible/install_spectrum_conductor_dli.yml
@@ -12,11 +12,10 @@
 
 - name: Download installer binary
   get_url:
-    owner: "{{ ansible_ssh_user }}"
-    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "$HOME"
+  become: yes
 
 - name: Include configuration environment variables
   include_vars:

--- a/software/wmla120_ansible/install_spectrum_conductor_with_spark.yml
+++ b/software/wmla120_ansible/install_spectrum_conductor_with_spark.yml
@@ -12,8 +12,8 @@
 
 - name: Download installer binary
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "{{ ansible_env.HOME }}"

--- a/software/wmla120_ansible/install_spectrum_conductor_with_spark.yml
+++ b/software/wmla120_ansible/install_spectrum_conductor_with_spark.yml
@@ -16,7 +16,7 @@
     group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"
 
 - name: Include configuration environment variables
   include_vars:
@@ -28,7 +28,7 @@
     filename: "{{ content_files['spectrum-conductor'].split('/')[-1] }}"
 
 - name: Install IBM Spectrum Conductor
-  shell: "{{ ansible_env.HOME }}/{{ filename }} --quiet"
+  shell: "$HOME/{{ filename }} --quiet"
   environment: "{{ envs }}"
   args:
     executable: /bin/bash

--- a/software/wmla120_ansible/install_spectrum_conductor_with_spark.yml
+++ b/software/wmla120_ansible/install_spectrum_conductor_with_spark.yml
@@ -12,11 +12,10 @@
 
 - name: Download installer binary
   get_url:
-    owner: "{{ ansible_ssh_user }}"
-    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "$HOME"
+  become: yes
 
 - name: Include configuration environment variables
   include_vars:

--- a/software/wmla120_ansible/powerai_license_install.yml
+++ b/software/wmla120_ansible/powerai_license_install.yml
@@ -12,8 +12,8 @@
 
 - name: Download license rpm
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/poweraie-license/{{ file }}"
     dest: "{{ ansible_env.HOME }}"

--- a/software/wmla120_ansible/powerai_license_install.yml
+++ b/software/wmla120_ansible/powerai_license_install.yml
@@ -16,10 +16,10 @@
     group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/poweraie-license/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"
 
 - name: Install powerai-enterprise-license
   yum:
-    name: "{{ ansible_env.HOME }}/{{ file }}"
+    name: "$HOME/{{ file }}"
     state: present
   become: yes

--- a/software/wmla120_ansible/wmla_license_install.yml
+++ b/software/wmla120_ansible/wmla_license_install.yml
@@ -20,7 +20,7 @@
     group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"
 
 - name: Get enterprise license filename from software-vars.yml
   set_fact:
@@ -30,5 +30,5 @@
 # # (accept-ibm-wmla-license.sh) Interactive license acceptance across the cluster
 # is orchestrated by the software install python module
 - name: Install wmla license
-  shell: "{{ install_dir }}/bin/conda install --yes --use-local file:/{{ ansible_env.HOME }}/{{ filename }}"
+  shell: "{{ install_dir }}/bin/conda install --yes --use-local file:/$HOME/{{ filename }}"
   become: yes

--- a/software/wmla120_ansible/wmla_license_install.yml
+++ b/software/wmla120_ansible/wmla_license_install.yml
@@ -16,8 +16,8 @@
 
 - name: Download license
   get_url:
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "{{ ansible_env.HOME }}"

--- a/software/wmla120_ansible/wmla_license_install.yml
+++ b/software/wmla120_ansible/wmla_license_install.yml
@@ -16,11 +16,10 @@
 
 - name: Download license
   get_url:
-    owner: "{{ ansible_ssh_user }}"
-    group: "{{ ansible_ssh_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
     dest: "$HOME"
+  become: yes
 
 - name: Get enterprise license filename from software-vars.yml
   set_fact:


### PR DESCRIPTION
The Ansible variable 'ansible_user_id' is dependent on Ansible facts
collection. For any task not utilization 'become' 'ansible_ssh_user' can
be used without needing to gather facts.