### PR TITLE
fix: Sanity check for conda free repo

### DIFF
--- a/software/wmla120.py
+++ b/software/wmla120.py
@@ -1111,7 +1111,7 @@ class software(object):
             # if not exists or ch == 'F':
             url = repo.get_repo_url(baseurl, alt_url, contains=['free', 'linux',
                                     f'{self.arch}'], excludes=['noarch', 'main'],
-                                    filelist=['cython-*'])
+                                    filelist=['redis-*'])
             if url:
                 if not url == baseurl:
                     self.sw_vars[f'{name}-alt-url'] = url


### PR DESCRIPTION
Use 'redis-*' in place of 'cython-*' as a sanity check for the right
repo when syncing content for conda-free.