### PR TITLE
fix: Install WMLA license to root home dir 

### DIFF
--- a/software/wmla120_ansible/wmla_license_check_and_install_to_root.yml
+++ b/software/wmla120_ansible/wmla_license_check_and_install_to_root.yml
@@ -1,23 +1,26 @@
 ---
-- name: Check that the status.dat file exists
+- name: Check if the status.dat file exists in root home dir
   stat:
-    path: "/root/.powerai/ibm-wmla-license/1.2.0/license/status.dat"
+    path: "$HOME/.powerai/ibm-wmla-license/1.2.0/license/status.dat"
   register: stat_result
   become: yes
 
-- name: Check that the status.dat file exists for eval version
+- name: Check if the status.dat file exists for eval version in root home dir
   stat:
-    path: "/root/.powerai/ibm-wmla-license-eval/1.2.0/license/status.dat"
+    path: "$HOME/.powerai/ibm-wmla-license-eval/1.2.0/license/status.dat"
   register: stat_result_eval
   become: yes
 
 - name: Fail if license not accepted
   fail:
     msg: "The WMLA license has not been accepted"
-  when: (not stat_result.stat.exists) and not eval_ver
+  when:
+    - not eval_ver
+    - not stat_result.stat.exists
 
 - name: Fail if eval license not accepted
   fail:
     msg: "The WMLA evaluation license has not been accepted"
-  when: (not stat_result_eval.stat.exists) and eval_ver
-
+  when:
+    - eval_ver
+    - not stat_result_eval.stat.exists

--- a/software/wmla120_ansible/wmla_license_install.yml
+++ b/software/wmla120_ansible/wmla_license_install.yml
@@ -20,7 +20,8 @@
     group: "{{ ansible_user }}"
     mode: 0744
     url: "http://{{ host_ip.stdout }}/{{ file }}"
-    dest: "{{ ansible_env.HOME }}"
+    dest: "$HOME"
+  become: yes
 
 - name: Get enterprise license filename from software-vars.yml
   set_fact:
@@ -30,5 +31,5 @@
 # # (accept-ibm-wmla-license.sh) Interactive license acceptance across the cluster
 # is orchestrated by the software install python module
 - name: Install wmla license
-  shell: "{{ install_dir }}/bin/conda install --yes --use-local file:/{{ ansible_env.HOME }}/{{ filename }}"
+  shell: "{{ install_dir }}/bin/conda install --yes --use-local file:/$HOME/{{ filename }}"
   become: yes


### PR DESCRIPTION
If the WMLA license acceptance has already been completed on a node
using the user account (e.g. installer node during self-installation)
the 'status.dat' may be in the user's home directory, and the
'wmla_license_install.yml' tasks will _not_ generate a new 'status.dat'
in the root home directory.

With this fix, there is still an assumption that the license has been
accepted either as root or the WMLAE user account (typically
'egoadmin').