### PR TITLE
fix: Update pypi repo build error mask

### DIFF
--- a/scripts/python/repos.py
+++ b/scripts/python/repos.py
@@ -1026,8 +1026,9 @@ class PowerupPypiRepoFromRepo(PowerupRepo):
             print(pkg)
             resp, err, rc = sub_proc_exec(eval(cmd), shell=True)
             if rc != 0:
-                err_str = '"{PYTHON} setup.py egg_info" failed with error code 1 in'
-                if 'functools32' in resp or 'weave' in resp and err_str in err:
+                err_str = 'setup.py egg_info" failed with error code 1 in'
+                if ('functools32' in resp or 'weave' in resp or
+                        'gensim' in resp and err_str in err):
                     pass
                 else:
                     self.log.error('Error occured while downloading python packages: '


### PR DESCRIPTION
When downloading python packages from a pypi repository it is only
necessary to get the '*.tar.gz' archive. If there is a build error
(could be due to missing system dependencies on the installer, incorrect
python environment, etc.) it is safe to ignore since this it is not in
an equivalent runtime environment.