### PR TITLE
fix: Add inventory argument to reboot check method

### DIFF
--- a/software/wmla121.py
+++ b/software/wmla121.py
@@ -2145,7 +2145,8 @@ class software(object):
                     break
             heading1(f"Client Node Action: {task['description']}")
             if task['description'] == "Install CUDA":
-                _check_clients_needs_restarting()
+                _check_clients_needs_restarting(
+                    self.sw_vars['ansible_inventory'])
             elif task['description'] == "Install Anaconda installer" and not self.sw_vars["public"]:
                 _interactive_anaconda_license_accept(
                     self.sw_vars['ansible_inventory'],


### PR DESCRIPTION
The call to '_check_clients_needs_restarting' is missing a required
argument to pass in the client inventory.