### PR TITLE
fix: Set Nginx status when not running

### DIFF
--- a/software/wmla121.py
+++ b/software/wmla121.py
@@ -493,6 +493,7 @@ class software(object):
                     pass
 
             else:
+                self.state[which] = Color.yellow + "Not running" + Color.endc
                 rc = False
 
             return rc


### PR DESCRIPTION
The Nginx status state was not being set when Nginx was not running.