### PR TITLE
fix: Increase Ansible default timeout value

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -14,3 +14,5 @@ retry_files_enabled = False
 debug = False
 verbosity = 4
 remote_tmp = /tmp/
+local_tmp = /tmp/
+timeout = 60


### PR DESCRIPTION
The Ansible 'get_url' module has been failing due to timeouts when
running with the installer as a cluster node. Subsequent retries are
working so possibly a larger timeout will allow it to pass on the first
try.